### PR TITLE
fix issues in VL53L1_I2CWrite and VL53L1_I2CRead with 16bit indexes

### DIFF
--- a/src/vl53l1_class.cpp
+++ b/src/vl53l1_class.cpp
@@ -3856,9 +3856,7 @@ VL53L1_Error VL53L1::VL53L1_I2CRead(uint8_t DeviceAddr, uint16_t RegisterAddr, u
     Serial.print("Writing port number ");
     Serial.println(RegisterAddr);
 #endif
-    uint8_t buffer[2];
-    buffer[0] = (uint8_t) RegisterAddr >> 8;
-    buffer[1] = (uint8_t) RegisterAddr & 0xFF;
+    const uint8_t buffer[2] {RegisterAddr >> 8, RegisterAddr & 0xFF };
     dev_i2c->write(buffer, 2);
     status = dev_i2c->endTransmission(false);
     //Fix for some STM32 boards

--- a/src/vl53l1_class.cpp
+++ b/src/vl53l1_class.cpp
@@ -3842,7 +3842,7 @@ VL53L1_Error VL53L1::VL53L1_I2CWrite(uint8_t DeviceAddr, uint8_t RegisterAddr, u
   return 0;
 }
 
-VL53L1_Error VL53L1::VL53L1_I2CRead(uint8_t DeviceAddr, uint8_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToRead)
+VL53L1_Error VL53L1::VL53L1_I2CRead(uint8_t DeviceAddr, uint16_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToRead)
 {
   int status = 0;
   //Loop until the port is transmitted correctly

--- a/src/vl53l1_class.cpp
+++ b/src/vl53l1_class.cpp
@@ -3830,9 +3830,7 @@ VL53L1_Error VL53L1::VL53L1_I2CWrite(uint8_t DeviceAddr, uint16_t RegisterAddr, 
   Serial.print("Writing port number ");
   Serial.println(RegisterAddr);
 #endif
-  uint8_t buffer[2];
-  buffer[0] = (uint8_t) RegisterAddr >> 8;
-  buffer[1] = (uint8_t) RegisterAddr & 0xFF;
+  const uint8_t buffer[2] {RegisterAddr >> 8, RegisterAddr & 0xFF };
   dev_i2c->write(buffer, 2);
   for (int i = 0 ; i < NumByteToWrite ; i++) {
     dev_i2c->write(pBuffer[i]);

--- a/src/vl53l1_class.cpp
+++ b/src/vl53l1_class.cpp
@@ -3819,7 +3819,7 @@ VL53L1_Error VL53L1::VL53L1_ReadMulti(VL53L1_DEV Dev, uint16_t index, uint8_t *p
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_I2CWrite(uint8_t DeviceAddr, uint8_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToWrite)
+VL53L1_Error VL53L1::VL53L1_I2CWrite(uint8_t DeviceAddr, uint16_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToWrite)
 {
 #ifdef DEBUG_MODE
   Serial.print("Beginning transmission to ");

--- a/src/vl53l1_class.h
+++ b/src/vl53l1_class.h
@@ -5298,7 +5298,7 @@ class VL53L1 : public RangeSensor {
     VL53L1_Error VL53L1_ReadMulti(VL53L1_DEV Dev, uint16_t index, uint8_t *pdata, uint32_t count);
 
     VL53L1_Error VL53L1_I2CWrite(uint8_t DeviceAddr, uint8_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToWrite);
-    VL53L1_Error VL53L1_I2CRead(uint8_t DeviceAddr, uint8_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToRead);
+    VL53L1_Error VL53L1_I2CRead(uint8_t DeviceAddr, uint16_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToRead);
     VL53L1_Error VL53L1_GetTickCount(uint32_t *ptick_count_ms);
     VL53L1_Error VL53L1_WaitUs(VL53L1_Dev_t *pdev, int32_t wait_us);
     VL53L1_Error VL53L1_WaitMs(VL53L1_Dev_t *pdev, int32_t wait_ms);

--- a/src/vl53l1_class.h
+++ b/src/vl53l1_class.h
@@ -5297,7 +5297,7 @@ class VL53L1 : public RangeSensor {
     VL53L1_Error VL53L1_WriteMulti(VL53L1_DEV Dev, uint16_t index, uint8_t *pdata, uint32_t count);
     VL53L1_Error VL53L1_ReadMulti(VL53L1_DEV Dev, uint16_t index, uint8_t *pdata, uint32_t count);
 
-    VL53L1_Error VL53L1_I2CWrite(uint8_t DeviceAddr, uint8_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToWrite);
+    VL53L1_Error VL53L1_I2CWrite(uint8_t DeviceAddr, uint16_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToWrite);
     VL53L1_Error VL53L1_I2CRead(uint8_t DeviceAddr, uint16_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToRead);
     VL53L1_Error VL53L1_GetTickCount(uint32_t *ptick_count_ms);
     VL53L1_Error VL53L1_WaitUs(VL53L1_Dev_t *pdev, int32_t wait_us);


### PR DESCRIPTION
- parameter data type must be at least 16bit long
- C-style cast was breaking index as it has higher operator precedence than the shift operator