### PR TITLE
Pretty up sensor identification output for debugging.

### DIFF
--- a/src/vl53l1_class.h
+++ b/src/vl53l1_class.h
@@ -341,12 +341,12 @@ class VL53L1 : public RangeSensor {
 #ifdef DEBUG_MODE
       uint8_t byteData;
       uint16_t wordData;
-      status = VL53L1_RdByte(Dev, 0x010F, &byteData);
+      status = VL53L1_RdByte(Dev, VL53L1_IDENTIFICATION__MODEL_ID, &byteData);
       Serial.println("VL53L1 Model_ID: " + String(byteData));
-      status = VL53L1_RdByte(Dev, 0x0110, &byteData);
+      status = VL53L1_RdByte(Dev, VL53L1_IDENTIFICATION__MODULE_TYPE, &byteData);
       Serial.println("VL53L1 Module_Type: " + String(byteData));
-      status = VL53L1_RdWord(Dev, 0x010F, &wordData);
-      Serial.println("VL53L1: " + String(wordData));
+      status = VL53L1_RdWord(Dev, VL53L1_IDENTIFICATION__MODULE_ID, &wordData);
+      Serial.println("VL53L1 Module_ID: " + String(wordData));
 #endif
 
       if (status == VL53L1_ERROR_NONE) {


### PR DESCRIPTION
Use existing preprocessor macros instead of "magic numbers" as register index.

Also the last read, seems to address a 2 byte (word) register. Thus probably the *module* ID was meat to be read, instead of the *model* ID, which is only 1 byte.

The definitions for the preprocessor macros are in [this line][1] and following.

[1]: https://github.com/stm32duino/VL53L1/blob/bdd638738f21d48e2067a147063b5e267ecf030c/src/vl53l1_register_map.h#L707