### PR TITLE
Replace VL53L1_GetTickCount() by millis().

### DIFF
--- a/src/vl53l1_class.cpp
+++ b/src/vl53l1_class.cpp
@@ -3879,18 +3879,6 @@ VL53L1_Error VL53L1::VL53L1_I2CRead(uint8_t DeviceAddr, uint16_t RegisterAddr, u
   return 0;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetTickCount(uint32_t *ptick_count_ms)
-{
-  /* Returns current tick count in [ms] */
-
-  VL53L1_Error status  = VL53L1_ERROR_NONE;
-
-  //*ptick_count_ms = timeGetTime();
-  *ptick_count_ms = 0;
-
-  return status;
-}
-
 VL53L1_Error VL53L1::VL53L1_WaitUs(VL53L1_Dev_t *pdev, int32_t wait_us)
 {
   (void)pdev;
@@ -3919,17 +3907,10 @@ VL53L1_Error VL53L1::VL53L1_WaitValueMaskEx(VL53L1_Dev_t *pdev, uint32_t timeout
    */
 
   VL53L1_Error status         = VL53L1_ERROR_NONE;
-  uint32_t     start_time_ms = 0;
-  uint32_t     current_time_ms = 0;
+  const auto   start_time_ms   = millis();
   uint32_t     polling_time_ms = 0;
   uint8_t      byte_value      = 0;
   uint8_t      found           = 0;
-
-
-
-  /* calculate time limit in absolute time */
-
-  VL53L1_GetTickCount(&start_time_ms);
 
   /* remember current trace functions and temporarily disable
    * function logging
@@ -3961,8 +3942,7 @@ VL53L1_Error VL53L1::VL53L1_WaitValueMaskEx(VL53L1_Dev_t *pdev, uint32_t timeout
 
     /* Update polling time (Compare difference rather than absolute to
        negate 32bit wrap around issue) */
-    VL53L1_GetTickCount(&current_time_ms);
-    polling_time_ms = current_time_ms - start_time_ms;
+    polling_time_ms = static_cast<std::uint32_t>(millis() - start_time_ms);
 
   }
 

--- a/src/vl53l1_class.h
+++ b/src/vl53l1_class.h
@@ -5299,7 +5299,6 @@ class VL53L1 : public RangeSensor {
 
     VL53L1_Error VL53L1_I2CWrite(uint8_t DeviceAddr, uint16_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToWrite);
     VL53L1_Error VL53L1_I2CRead(uint8_t DeviceAddr, uint16_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToRead);
-    VL53L1_Error VL53L1_GetTickCount(uint32_t *ptick_count_ms);
     VL53L1_Error VL53L1_WaitUs(VL53L1_Dev_t *pdev, int32_t wait_us);
     VL53L1_Error VL53L1_WaitMs(VL53L1_Dev_t *pdev, int32_t wait_ms);
 

--- a/src/vl53l1_wait.cpp
+++ b/src/vl53l1_wait.cpp
@@ -425,14 +425,10 @@ VL53L1_Error VL53L1::VL53L1_poll_for_firmware_ready(
   VL53L1_Error status          = VL53L1_ERROR_NONE;
   VL53L1_LLDriverData_t *pdev = VL53L1DevStructGetLLDriverHandle(Dev);
 
-  uint32_t     start_time_ms   = 0;
-  uint32_t     current_time_ms = 0;
+  const auto   start_time_ms   = millis();
   int32_t      poll_delay_ms   = VL53L1_POLLING_DELAY_MS;
   uint8_t      fw_ready        = 0;
 
-
-
-  VL53L1_GetTickCount(&start_time_ms);
   pdev->fw_ready_poll_duration_ms = 0;
 
 
@@ -454,9 +450,8 @@ VL53L1_Error VL53L1::VL53L1_poll_for_firmware_ready(
     }
 
 
-    VL53L1_GetTickCount(&current_time_ms);
     pdev->fw_ready_poll_duration_ms =
-      current_time_ms - start_time_ms;
+      static_cast<std::uint32_t>(millis() - start_time_ms);
   }
 
   if (fw_ready == 0 && status == VL53L1_ERROR_NONE) {


### PR DESCRIPTION
The current implementation of VL53L1_GetTickCount() has several drawbacks:

 - it does not work: time is always set to 0
 - the return value is meaningless: it is always VL53L1_ERROR_NONE
 - the parameter type is questionable: unsigned long would be better

Instead use millis() of the standard Arduino library.