### PR TITLE
allow different XSHUT control mechanisms

### DIFF
--- a/src/vl53l1_api_calibration.cpp
+++ b/src/vl53l1_api_calibration.cpp
@@ -69,7 +69,7 @@
 #include "vl53l1_class.h"
 
 
-VL53L1_Error VL53L1::VL53L1_run_ref_spad_char(
+VL53L1_Error VL53L1Base::VL53L1_run_ref_spad_char(
   VL53L1_DEV        Dev,
   VL53L1_Error     *pcal_status)
 {
@@ -225,7 +225,7 @@ VL53L1_Error VL53L1::VL53L1_run_ref_spad_char(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_run_xtalk_extraction(
+VL53L1_Error VL53L1Base::VL53L1_run_xtalk_extraction(
   VL53L1_DEV                          Dev,
   VL53L1_Error                       *pcal_status)
 {
@@ -489,7 +489,7 @@ VL53L1_Error VL53L1::VL53L1_run_xtalk_extraction(
 
 
 
-VL53L1_Error VL53L1::VL53L1_get_and_avg_xtalk_samples(
+VL53L1_Error VL53L1Base::VL53L1_get_and_avg_xtalk_samples(
   VL53L1_DEV                    Dev,
   uint8_t                       num_of_samples,
   uint8_t                       measurement_mode,
@@ -748,7 +748,7 @@ VL53L1_Error VL53L1::VL53L1_get_and_avg_xtalk_samples(
 
 
 
-VL53L1_Error VL53L1::VL53L1_run_offset_calibration(
+VL53L1_Error VL53L1Base::VL53L1_run_offset_calibration(
   VL53L1_DEV                    Dev,
   int16_t                       cal_distance_mm,
   uint16_t                      cal_reflectance_pc,
@@ -1136,7 +1136,7 @@ VL53L1_Error VL53L1::VL53L1_run_offset_calibration(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_run_phasecal_average(
+VL53L1_Error VL53L1Base::VL53L1_run_phasecal_average(
   VL53L1_DEV              Dev,
   uint8_t                 measurement_mode,
   uint8_t                 phasecal_result__vcsel_start,
@@ -1268,7 +1268,7 @@ VL53L1_Error VL53L1::VL53L1_run_phasecal_average(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_run_zone_calibration(
+VL53L1_Error VL53L1Base::VL53L1_run_zone_calibration(
   VL53L1_DEV                    Dev,
   VL53L1_DevicePresetModes      device_preset_mode,
   VL53L1_DeviceZonePreset       zone_preset,
@@ -1589,7 +1589,7 @@ VL53L1_Error VL53L1::VL53L1_run_zone_calibration(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_run_spad_rate_map(
+VL53L1_Error VL53L1Base::VL53L1_run_spad_rate_map(
   VL53L1_DEV                 Dev,
   VL53L1_DeviceTestMode      device_test_mode,
   VL53L1_DeviceSscArray      array_select,
@@ -1657,7 +1657,7 @@ VL53L1_Error VL53L1::VL53L1_run_spad_rate_map(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_run_device_test(
+VL53L1_Error VL53L1Base::VL53L1_run_device_test(
   VL53L1_DEV             Dev,
   VL53L1_DeviceTestMode  device_test_mode)
 {
@@ -1734,7 +1734,7 @@ VL53L1_Error VL53L1::VL53L1_run_device_test(
 }
 
 
-void VL53L1::VL53L1_hist_xtalk_extract_data_init(
+void VL53L1Base::VL53L1_hist_xtalk_extract_data_init(
   VL53L1_hist_xtalk_extract_data_t *pxtalk_data)
 {
 
@@ -1762,7 +1762,7 @@ void VL53L1::VL53L1_hist_xtalk_extract_data_init(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_hist_xtalk_extract_update(
+VL53L1_Error VL53L1Base::VL53L1_hist_xtalk_extract_update(
   int16_t                             target_distance_mm,
   uint16_t                            target_width_oversize,
   VL53L1_histogram_bin_data_t        *phist_bins,
@@ -1794,7 +1794,7 @@ VL53L1_Error VL53L1::VL53L1_hist_xtalk_extract_update(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_hist_xtalk_extract_fini(
+VL53L1_Error VL53L1Base::VL53L1_hist_xtalk_extract_fini(
   VL53L1_histogram_bin_data_t        *phist_bins,
   VL53L1_hist_xtalk_extract_data_t   *pxtalk_data,
   VL53L1_xtalk_calibration_results_t *pxtalk_cal,
@@ -1872,7 +1872,7 @@ VL53L1_Error VL53L1::VL53L1_hist_xtalk_extract_fini(
 }
 
 
-VL53L1_Error   VL53L1::VL53L1_run_hist_xtalk_extraction(
+VL53L1_Error   VL53L1Base::VL53L1_run_hist_xtalk_extraction(
   VL53L1_DEV                          Dev,
   int16_t                             cal_distance_mm,
   VL53L1_Error                       *pcal_status)

--- a/src/vl53l1_api_core.cpp
+++ b/src/vl53l1_api_core.cpp
@@ -71,7 +71,7 @@
 #define VL53L1_MAX_I2C_XFER_SIZE 256
 
 VL53L1_Error VL53L1Base::select_offset_per_vcsel(VL53L1_LLDriverData_t *pdev,
-                                             int16_t *poffset)
+                                                 int16_t *poffset)
 {
   VL53L1_Error status = VL53L1_ERROR_NONE;
   int16_t tA, tB;
@@ -105,8 +105,8 @@ VL53L1_Error VL53L1Base::select_offset_per_vcsel(VL53L1_LLDriverData_t *pdev,
 }
 
 void VL53L1Base::vl53l1_diff_histo_stddev(VL53L1_LLDriverData_t *pdev,
-                                      VL53L1_histogram_bin_data_t *pdata, uint8_t timing, uint8_t HighIndex,
-                                      uint8_t prev_pos, int32_t *pdiff_histo_stddev)
+                                          VL53L1_histogram_bin_data_t *pdata, uint8_t timing, uint8_t HighIndex,
+                                          uint8_t prev_pos, int32_t *pdiff_histo_stddev)
 {
   uint16_t   bin                      = 0;
   int32_t    total_rate_pre = 0;
@@ -134,7 +134,7 @@ void VL53L1Base::vl53l1_diff_histo_stddev(VL53L1_LLDriverData_t *pdev,
 }
 
 void VL53L1Base::vl53l1_histo_merge(VL53L1_DEV Dev,
-                                VL53L1_histogram_bin_data_t *pdata)
+                                    VL53L1_histogram_bin_data_t *pdata)
 {
   VL53L1_LLDriverData_t *pdev =
     VL53L1DevStructGetLLDriverHandle(Dev);

--- a/src/vl53l1_api_core.cpp
+++ b/src/vl53l1_api_core.cpp
@@ -70,7 +70,7 @@
 
 #define VL53L1_MAX_I2C_XFER_SIZE 256
 
-VL53L1_Error VL53L1::select_offset_per_vcsel(VL53L1_LLDriverData_t *pdev,
+VL53L1_Error VL53L1Base::select_offset_per_vcsel(VL53L1_LLDriverData_t *pdev,
                                              int16_t *poffset)
 {
   VL53L1_Error status = VL53L1_ERROR_NONE;
@@ -104,7 +104,7 @@ VL53L1_Error VL53L1::select_offset_per_vcsel(VL53L1_LLDriverData_t *pdev,
   return status;
 }
 
-void VL53L1::vl53l1_diff_histo_stddev(VL53L1_LLDriverData_t *pdev,
+void VL53L1Base::vl53l1_diff_histo_stddev(VL53L1_LLDriverData_t *pdev,
                                       VL53L1_histogram_bin_data_t *pdata, uint8_t timing, uint8_t HighIndex,
                                       uint8_t prev_pos, int32_t *pdiff_histo_stddev)
 {
@@ -133,7 +133,7 @@ void VL53L1::vl53l1_diff_histo_stddev(VL53L1_LLDriverData_t *pdev,
     }
 }
 
-void VL53L1::vl53l1_histo_merge(VL53L1_DEV Dev,
+void VL53L1Base::vl53l1_histo_merge(VL53L1_DEV Dev,
                                 VL53L1_histogram_bin_data_t *pdata)
 {
   VL53L1_LLDriverData_t *pdev =
@@ -221,7 +221,7 @@ void VL53L1::vl53l1_histo_merge(VL53L1_DEV Dev,
   }
 }
 
-VL53L1_Error VL53L1::VL53L1_load_patch(
+VL53L1_Error VL53L1Base::VL53L1_load_patch(
   VL53L1_DEV Dev)
 {
   VL53L1_Error status = VL53L1_ERROR_NONE;
@@ -310,7 +310,7 @@ VL53L1_Error VL53L1::VL53L1_load_patch(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_unload_patch(
+VL53L1_Error VL53L1Base::VL53L1_unload_patch(
   VL53L1_DEV Dev)
 {
   VL53L1_Error status = VL53L1_ERROR_NONE;
@@ -336,7 +336,7 @@ VL53L1_Error VL53L1::VL53L1_unload_patch(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_get_version(
+VL53L1_Error VL53L1Base::VL53L1_get_version(
   VL53L1_DEV           Dev,
   VL53L1_ll_version_t *pdata)
 {
@@ -352,7 +352,7 @@ VL53L1_Error VL53L1::VL53L1_get_version(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_device_firmware_version(
+VL53L1_Error VL53L1Base::VL53L1_get_device_firmware_version(
   VL53L1_DEV        Dev,
   uint16_t         *pfw_version)
 {
@@ -382,7 +382,7 @@ VL53L1_Error VL53L1::VL53L1_get_device_firmware_version(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_data_init(
+VL53L1_Error VL53L1Base::VL53L1_data_init(
   VL53L1_DEV        Dev,
   uint8_t           read_p2p_data)
 {
@@ -580,7 +580,7 @@ VL53L1_Error VL53L1::VL53L1_data_init(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_read_p2p_data(
+VL53L1_Error VL53L1Base::VL53L1_read_p2p_data(
   VL53L1_DEV        Dev)
 {
 
@@ -746,7 +746,7 @@ VL53L1_Error VL53L1::VL53L1_read_p2p_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_software_reset(
+VL53L1_Error VL53L1Base::VL53L1_software_reset(
   VL53L1_DEV    Dev)
 {
 
@@ -787,7 +787,7 @@ VL53L1_Error VL53L1::VL53L1_software_reset(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_part_to_part_data(
+VL53L1_Error VL53L1Base::VL53L1_set_part_to_part_data(
   VL53L1_DEV                            Dev,
   VL53L1_calibration_data_t            *pcal_data)
 {
@@ -908,7 +908,7 @@ VL53L1_Error VL53L1::VL53L1_set_part_to_part_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_part_to_part_data(
+VL53L1_Error VL53L1Base::VL53L1_get_part_to_part_data(
   VL53L1_DEV                      Dev,
   VL53L1_calibration_data_t      *pcal_data)
 {
@@ -999,7 +999,7 @@ VL53L1_Error VL53L1::VL53L1_get_part_to_part_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_inter_measurement_period_ms(
+VL53L1_Error VL53L1Base::VL53L1_set_inter_measurement_period_ms(
   VL53L1_DEV              Dev,
   uint32_t                inter_measurement_period_ms)
 {
@@ -1027,7 +1027,7 @@ VL53L1_Error VL53L1::VL53L1_set_inter_measurement_period_ms(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_inter_measurement_period_ms(
+VL53L1_Error VL53L1Base::VL53L1_get_inter_measurement_period_ms(
   VL53L1_DEV              Dev,
   uint32_t               *pinter_measurement_period_ms)
 {
@@ -1054,7 +1054,7 @@ VL53L1_Error VL53L1::VL53L1_get_inter_measurement_period_ms(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_timeouts_us(
+VL53L1_Error VL53L1Base::VL53L1_set_timeouts_us(
   VL53L1_DEV          Dev,
   uint32_t            phasecal_config_timeout_us,
   uint32_t            mm_config_timeout_us,
@@ -1094,7 +1094,7 @@ VL53L1_Error VL53L1::VL53L1_set_timeouts_us(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_timeouts_us(
+VL53L1_Error VL53L1Base::VL53L1_get_timeouts_us(
   VL53L1_DEV           Dev,
   uint32_t            *pphasecal_config_timeout_us,
   uint32_t            *pmm_config_timeout_us,
@@ -1166,7 +1166,7 @@ VL53L1_Error VL53L1::VL53L1_get_timeouts_us(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_calibration_repeat_period(
+VL53L1_Error VL53L1Base::VL53L1_set_calibration_repeat_period(
   VL53L1_DEV          Dev,
   uint16_t            cal_config__repeat_period)
 {
@@ -1183,7 +1183,7 @@ VL53L1_Error VL53L1::VL53L1_set_calibration_repeat_period(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_calibration_repeat_period(
+VL53L1_Error VL53L1Base::VL53L1_get_calibration_repeat_period(
   VL53L1_DEV          Dev,
   uint16_t           *pcal_config__repeat_period)
 {
@@ -1200,7 +1200,7 @@ VL53L1_Error VL53L1::VL53L1_get_calibration_repeat_period(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_sequence_config_bit(
+VL53L1_Error VL53L1Base::VL53L1_set_sequence_config_bit(
   VL53L1_DEV                    Dev,
   VL53L1_DeviceSequenceConfig   bit_id,
   uint8_t                       value)
@@ -1236,7 +1236,7 @@ VL53L1_Error VL53L1::VL53L1_set_sequence_config_bit(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_sequence_config_bit(
+VL53L1_Error VL53L1Base::VL53L1_get_sequence_config_bit(
   VL53L1_DEV                    Dev,
   VL53L1_DeviceSequenceConfig   bit_id,
   uint8_t                      *pvalue)
@@ -1270,7 +1270,7 @@ VL53L1_Error VL53L1::VL53L1_get_sequence_config_bit(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_interrupt_polarity(
+VL53L1_Error VL53L1Base::VL53L1_set_interrupt_polarity(
   VL53L1_DEV                      Dev,
   VL53L1_DeviceInterruptPolarity  interrupt_polarity)
 {
@@ -1291,7 +1291,7 @@ VL53L1_Error VL53L1::VL53L1_set_interrupt_polarity(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_refspadchar_config_struct(
+VL53L1_Error VL53L1Base::VL53L1_set_refspadchar_config_struct(
   VL53L1_DEV                     Dev,
   VL53L1_refspadchar_config_t   *pdata)
 {
@@ -1318,7 +1318,7 @@ VL53L1_Error VL53L1::VL53L1_set_refspadchar_config_struct(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_get_refspadchar_config_struct(
+VL53L1_Error VL53L1Base::VL53L1_get_refspadchar_config_struct(
   VL53L1_DEV                     Dev,
   VL53L1_refspadchar_config_t   *pdata)
 {
@@ -1347,7 +1347,7 @@ VL53L1_Error VL53L1::VL53L1_get_refspadchar_config_struct(
 
 
 
-VL53L1_Error VL53L1::VL53L1_set_range_ignore_threshold(
+VL53L1_Error VL53L1Base::VL53L1_set_range_ignore_threshold(
   VL53L1_DEV              Dev,
   uint8_t                 range_ignore_thresh_mult,
   uint16_t                range_ignore_threshold_mcps)
@@ -1368,7 +1368,7 @@ VL53L1_Error VL53L1::VL53L1_set_range_ignore_threshold(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_get_range_ignore_threshold(
+VL53L1_Error VL53L1Base::VL53L1_get_range_ignore_threshold(
   VL53L1_DEV              Dev,
   uint8_t                *prange_ignore_thresh_mult,
   uint16_t               *prange_ignore_threshold_mcps_internal,
@@ -1395,7 +1395,7 @@ VL53L1_Error VL53L1::VL53L1_get_range_ignore_threshold(
 
 
 
-VL53L1_Error VL53L1::VL53L1_get_interrupt_polarity(
+VL53L1_Error VL53L1Base::VL53L1_get_interrupt_polarity(
   VL53L1_DEV                       Dev,
   VL53L1_DeviceInterruptPolarity  *pinterrupt_polarity)
 {
@@ -1414,7 +1414,7 @@ VL53L1_Error VL53L1::VL53L1_get_interrupt_polarity(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_user_zone(
+VL53L1_Error VL53L1Base::VL53L1_set_user_zone(
   VL53L1_DEV              Dev,
   VL53L1_user_zone_t     *puser_zone)
 {
@@ -1445,7 +1445,7 @@ VL53L1_Error VL53L1::VL53L1_set_user_zone(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_user_zone(
+VL53L1_Error VL53L1Base::VL53L1_get_user_zone(
   VL53L1_DEV              Dev,
   VL53L1_user_zone_t     *puser_zone)
 {
@@ -1475,7 +1475,7 @@ VL53L1_Error VL53L1::VL53L1_get_user_zone(
 
 
 
-VL53L1_Error VL53L1::VL53L1_get_mode_mitigation_roi(
+VL53L1_Error VL53L1Base::VL53L1_get_mode_mitigation_roi(
   VL53L1_DEV              Dev,
   VL53L1_user_zone_t     *pmm_roi)
 {
@@ -1511,7 +1511,7 @@ VL53L1_Error VL53L1::VL53L1_get_mode_mitigation_roi(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_zone_config(
+VL53L1_Error VL53L1Base::VL53L1_set_zone_config(
   VL53L1_DEV                 Dev,
   VL53L1_zone_config_t      *pzone_cfg)
 {
@@ -1551,7 +1551,7 @@ VL53L1_Error VL53L1::VL53L1_set_zone_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_zone_config(
+VL53L1_Error VL53L1Base::VL53L1_get_zone_config(
   VL53L1_DEV                 Dev,
   VL53L1_zone_config_t      *pzone_cfg)
 {
@@ -1570,7 +1570,7 @@ VL53L1_Error VL53L1::VL53L1_get_zone_config(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_get_preset_mode_timing_cfg(
+VL53L1_Error VL53L1Base::VL53L1_get_preset_mode_timing_cfg(
   VL53L1_DEV                   Dev,
   VL53L1_DevicePresetModes     device_preset_mode,
   uint16_t                    *pdss_config__target_total_rate_mcps,
@@ -1744,7 +1744,7 @@ VL53L1_Error VL53L1::VL53L1_get_preset_mode_timing_cfg(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_preset_mode(
+VL53L1_Error VL53L1Base::VL53L1_set_preset_mode(
   VL53L1_DEV                   Dev,
   VL53L1_DevicePresetModes     device_preset_mode,
   uint16_t                     dss_config__target_total_rate_mcps,
@@ -2310,7 +2310,7 @@ VL53L1_Error VL53L1::VL53L1_set_preset_mode(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_zone_preset(
+VL53L1_Error VL53L1Base::VL53L1_set_zone_preset(
   VL53L1_DEV                 Dev,
   VL53L1_DeviceZonePreset    zone_preset)
 {
@@ -2448,7 +2448,7 @@ VL53L1_Error VL53L1::VL53L1_set_zone_preset(
 }
 
 
-VL53L1_Error  VL53L1::VL53L1_enable_xtalk_compensation(
+VL53L1_Error  VL53L1Base::VL53L1_enable_xtalk_compensation(
   VL53L1_DEV                 Dev)
 {
 
@@ -2524,7 +2524,7 @@ VL53L1_Error  VL53L1::VL53L1_enable_xtalk_compensation(
 
 }
 
-void VL53L1::VL53L1_get_xtalk_compensation_enable(
+void VL53L1Base::VL53L1_get_xtalk_compensation_enable(
   VL53L1_DEV    Dev,
   uint8_t       *pcrosstalk_compensation_enable)
 {
@@ -2542,7 +2542,7 @@ void VL53L1::VL53L1_get_xtalk_compensation_enable(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_lite_xtalk_margin_kcps(
+VL53L1_Error VL53L1Base::VL53L1_get_lite_xtalk_margin_kcps(
   VL53L1_DEV                          Dev,
   int16_t                           *pxtalk_margin)
 {
@@ -2563,7 +2563,7 @@ VL53L1_Error VL53L1::VL53L1_get_lite_xtalk_margin_kcps(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_set_lite_xtalk_margin_kcps(
+VL53L1_Error VL53L1Base::VL53L1_set_lite_xtalk_margin_kcps(
   VL53L1_DEV                     Dev,
   int16_t                        xtalk_margin)
 {
@@ -2584,7 +2584,7 @@ VL53L1_Error VL53L1::VL53L1_set_lite_xtalk_margin_kcps(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_histogram_xtalk_margin_kcps(
+VL53L1_Error VL53L1Base::VL53L1_get_histogram_xtalk_margin_kcps(
   VL53L1_DEV                          Dev,
   int16_t                           *pxtalk_margin)
 {
@@ -2605,7 +2605,7 @@ VL53L1_Error VL53L1::VL53L1_get_histogram_xtalk_margin_kcps(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_set_histogram_xtalk_margin_kcps(
+VL53L1_Error VL53L1Base::VL53L1_set_histogram_xtalk_margin_kcps(
   VL53L1_DEV                     Dev,
   int16_t                        xtalk_margin)
 {
@@ -2625,7 +2625,7 @@ VL53L1_Error VL53L1::VL53L1_set_histogram_xtalk_margin_kcps(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_restore_xtalk_nvm_default(
+VL53L1_Error VL53L1Base::VL53L1_restore_xtalk_nvm_default(
   VL53L1_DEV                     Dev)
 {
 
@@ -2650,7 +2650,7 @@ VL53L1_Error VL53L1::VL53L1_restore_xtalk_nvm_default(
   return status;
 }
 
-VL53L1_Error  VL53L1::VL53L1_disable_xtalk_compensation(
+VL53L1_Error  VL53L1Base::VL53L1_disable_xtalk_compensation(
   VL53L1_DEV                 Dev)
 {
 
@@ -2702,7 +2702,7 @@ VL53L1_Error  VL53L1::VL53L1_disable_xtalk_compensation(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_histogram_phase_consistency(
+VL53L1_Error VL53L1Base::VL53L1_get_histogram_phase_consistency(
   VL53L1_DEV                          Dev,
   uint8_t                            *pphase_consistency)
 {
@@ -2725,7 +2725,7 @@ VL53L1_Error VL53L1::VL53L1_get_histogram_phase_consistency(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_set_histogram_phase_consistency(
+VL53L1_Error VL53L1Base::VL53L1_set_histogram_phase_consistency(
   VL53L1_DEV                          Dev,
   uint8_t                             phase_consistency)
 {
@@ -2747,7 +2747,7 @@ VL53L1_Error VL53L1::VL53L1_set_histogram_phase_consistency(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_get_histogram_event_consistency(
+VL53L1_Error VL53L1Base::VL53L1_get_histogram_event_consistency(
   VL53L1_DEV                          Dev,
   uint8_t                            *pevent_consistency)
 {
@@ -2769,7 +2769,7 @@ VL53L1_Error VL53L1::VL53L1_get_histogram_event_consistency(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_set_histogram_event_consistency(
+VL53L1_Error VL53L1Base::VL53L1_set_histogram_event_consistency(
   VL53L1_DEV                          Dev,
   uint8_t                             event_consistency)
 {
@@ -2791,7 +2791,7 @@ VL53L1_Error VL53L1::VL53L1_set_histogram_event_consistency(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_get_histogram_ambient_threshold_sigma(
+VL53L1_Error VL53L1Base::VL53L1_get_histogram_ambient_threshold_sigma(
   VL53L1_DEV                          Dev,
   uint8_t                            *pamb_thresh_sigma)
 {
@@ -2813,7 +2813,7 @@ VL53L1_Error VL53L1::VL53L1_get_histogram_ambient_threshold_sigma(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_set_histogram_ambient_threshold_sigma(
+VL53L1_Error VL53L1Base::VL53L1_set_histogram_ambient_threshold_sigma(
   VL53L1_DEV                          Dev,
   uint8_t                             amb_thresh_sigma)
 {
@@ -2835,7 +2835,7 @@ VL53L1_Error VL53L1::VL53L1_set_histogram_ambient_threshold_sigma(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_get_lite_sigma_threshold(
+VL53L1_Error VL53L1Base::VL53L1_get_lite_sigma_threshold(
   VL53L1_DEV                          Dev,
   uint16_t                           *plite_sigma)
 {
@@ -2857,7 +2857,7 @@ VL53L1_Error VL53L1::VL53L1_get_lite_sigma_threshold(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_set_lite_sigma_threshold(
+VL53L1_Error VL53L1Base::VL53L1_set_lite_sigma_threshold(
   VL53L1_DEV                          Dev,
   uint16_t                           lite_sigma)
 {
@@ -2878,7 +2878,7 @@ VL53L1_Error VL53L1::VL53L1_set_lite_sigma_threshold(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_get_lite_min_count_rate(
+VL53L1_Error VL53L1Base::VL53L1_get_lite_min_count_rate(
   VL53L1_DEV                          Dev,
   uint16_t                           *plite_mincountrate)
 {
@@ -2900,7 +2900,7 @@ VL53L1_Error VL53L1::VL53L1_get_lite_min_count_rate(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_set_lite_min_count_rate(
+VL53L1_Error VL53L1Base::VL53L1_set_lite_min_count_rate(
   VL53L1_DEV                          Dev,
   uint16_t                            lite_mincountrate)
 {
@@ -2923,7 +2923,7 @@ VL53L1_Error VL53L1::VL53L1_set_lite_min_count_rate(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_xtalk_detect_config(
+VL53L1_Error VL53L1Base::VL53L1_get_xtalk_detect_config(
   VL53L1_DEV                          Dev,
   int16_t                            *pmax_valid_range_mm,
   int16_t                            *pmin_valid_range_mm,
@@ -2954,7 +2954,7 @@ VL53L1_Error VL53L1::VL53L1_get_xtalk_detect_config(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_set_xtalk_detect_config(
+VL53L1_Error VL53L1Base::VL53L1_set_xtalk_detect_config(
   VL53L1_DEV                          Dev,
   int16_t                             max_valid_range_mm,
   int16_t                             min_valid_range_mm,
@@ -2985,7 +2985,7 @@ VL53L1_Error VL53L1::VL53L1_set_xtalk_detect_config(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_get_target_order_mode(
+VL53L1_Error VL53L1Base::VL53L1_get_target_order_mode(
   VL53L1_DEV                          Dev,
   VL53L1_HistTargetOrder             *phist_target_order)
 {
@@ -3007,7 +3007,7 @@ VL53L1_Error VL53L1::VL53L1_get_target_order_mode(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_set_target_order_mode(
+VL53L1_Error VL53L1Base::VL53L1_set_target_order_mode(
   VL53L1_DEV                          Dev,
   VL53L1_HistTargetOrder              hist_target_order)
 {
@@ -3029,7 +3029,7 @@ VL53L1_Error VL53L1::VL53L1_set_target_order_mode(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_dmax_reflectance_values(
+VL53L1_Error VL53L1Base::VL53L1_get_dmax_reflectance_values(
   VL53L1_DEV                          Dev,
   VL53L1_dmax_reflectance_array_t    *pdmax_reflectances)
 {
@@ -3055,7 +3055,7 @@ VL53L1_Error VL53L1::VL53L1_get_dmax_reflectance_values(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_set_dmax_reflectance_values(
+VL53L1_Error VL53L1Base::VL53L1_set_dmax_reflectance_values(
   VL53L1_DEV                          Dev,
   VL53L1_dmax_reflectance_array_t    *pdmax_reflectances)
 {
@@ -3081,7 +3081,7 @@ VL53L1_Error VL53L1::VL53L1_set_dmax_reflectance_values(
 
 }
 
-VL53L1_Error VL53L1::VL53L1_get_vhv_loopbound(
+VL53L1_Error VL53L1Base::VL53L1_get_vhv_loopbound(
   VL53L1_DEV                   Dev,
   uint8_t                     *pvhv_loopbound)
 {
@@ -3105,7 +3105,7 @@ VL53L1_Error VL53L1::VL53L1_get_vhv_loopbound(
 
 
 
-VL53L1_Error VL53L1::VL53L1_set_vhv_loopbound(
+VL53L1_Error VL53L1Base::VL53L1_set_vhv_loopbound(
   VL53L1_DEV                   Dev,
   uint8_t                      vhv_loopbound)
 {
@@ -3130,7 +3130,7 @@ VL53L1_Error VL53L1::VL53L1_set_vhv_loopbound(
 
 
 
-VL53L1_Error VL53L1::VL53L1_get_vhv_config(
+VL53L1_Error VL53L1Base::VL53L1_get_vhv_config(
   VL53L1_DEV                   Dev,
   uint8_t                     *pvhv_init_en,
   uint8_t                     *pvhv_init_value)
@@ -3158,7 +3158,7 @@ VL53L1_Error VL53L1::VL53L1_get_vhv_config(
 
 
 
-VL53L1_Error VL53L1::VL53L1_set_vhv_config(
+VL53L1_Error VL53L1Base::VL53L1_set_vhv_config(
   VL53L1_DEV                   Dev,
   uint8_t                      vhv_init_en,
   uint8_t                      vhv_init_value)
@@ -3184,7 +3184,7 @@ VL53L1_Error VL53L1::VL53L1_set_vhv_config(
 
 
 
-VL53L1_Error VL53L1::VL53L1_init_and_start_range(
+VL53L1_Error VL53L1Base::VL53L1_init_and_start_range(
   VL53L1_DEV                     Dev,
   uint8_t                        measurement_mode,
   VL53L1_DeviceConfigLevel       device_config_level)
@@ -3475,7 +3475,7 @@ VL53L1_Error VL53L1::VL53L1_init_and_start_range(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_stop_range(
+VL53L1_Error VL53L1Base::VL53L1_stop_range(
   VL53L1_DEV     Dev)
 {
 
@@ -3525,7 +3525,7 @@ VL53L1_Error VL53L1::VL53L1_stop_range(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_measurement_results(
+VL53L1_Error VL53L1Base::VL53L1_get_measurement_results(
   VL53L1_DEV                     Dev,
   VL53L1_DeviceResultsLevel      device_results_level)
 {
@@ -3621,7 +3621,7 @@ VL53L1_Error VL53L1::VL53L1_get_measurement_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_device_results(
+VL53L1_Error VL53L1Base::VL53L1_get_device_results(
   VL53L1_DEV                    Dev,
   VL53L1_DeviceResultsLevel     device_results_level,
   VL53L1_range_results_t       *prange_results)
@@ -4053,7 +4053,7 @@ UPDATE_DYNAMIC_CONFIG:
 }
 
 
-VL53L1_Error VL53L1::VL53L1_clear_interrupt_and_enable_next_range(
+VL53L1_Error VL53L1Base::VL53L1_clear_interrupt_and_enable_next_range(
   VL53L1_DEV        Dev,
   uint8_t           measurement_mode)
 {
@@ -4085,7 +4085,7 @@ VL53L1_Error VL53L1::VL53L1_clear_interrupt_and_enable_next_range(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_histogram_bin_data(
+VL53L1_Error VL53L1Base::VL53L1_get_histogram_bin_data(
   VL53L1_DEV                   Dev,
   VL53L1_histogram_bin_data_t *pdata)
 {
@@ -4332,7 +4332,7 @@ VL53L1_Error VL53L1::VL53L1_get_histogram_bin_data(
 }
 
 
-void VL53L1::VL53L1_copy_sys_and_core_results_to_range_results(
+void VL53L1Base::VL53L1_copy_sys_and_core_results_to_range_results(
   int32_t                           gain_factor,
   VL53L1_system_results_t          *psys,
   VL53L1_core_results_t            *pcore,
@@ -4536,7 +4536,7 @@ void VL53L1::VL53L1_copy_sys_and_core_results_to_range_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_zone_dss_config(
+VL53L1_Error VL53L1Base::VL53L1_set_zone_dss_config(
   VL53L1_DEV                      Dev,
   VL53L1_zone_private_dyn_cfg_t  *pzone_dyn_cfg)
 {
@@ -4566,7 +4566,7 @@ VL53L1_Error VL53L1::VL53L1_set_zone_dss_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_calc_ambient_dmax(
+VL53L1_Error VL53L1Base::VL53L1_calc_ambient_dmax(
   VL53L1_DEV      Dev,
   uint16_t        target_reflectance,
   int16_t         *pambient_dmax_mm)
@@ -4609,7 +4609,7 @@ VL53L1_Error VL53L1::VL53L1_calc_ambient_dmax(
 
 
 
-VL53L1_Error VL53L1::VL53L1_set_GPIO_interrupt_config(
+VL53L1_Error VL53L1Base::VL53L1_set_GPIO_interrupt_config(
   VL53L1_DEV                      Dev,
   VL53L1_GPIO_Interrupt_Mode  intr_mode_distance,
   VL53L1_GPIO_Interrupt_Mode  intr_mode_rate,
@@ -4657,7 +4657,7 @@ VL53L1_Error VL53L1::VL53L1_set_GPIO_interrupt_config(
 
 
 
-VL53L1_Error VL53L1::VL53L1_set_GPIO_interrupt_config_struct(
+VL53L1_Error VL53L1Base::VL53L1_set_GPIO_interrupt_config_struct(
   VL53L1_DEV                      Dev,
   VL53L1_GPIO_interrupt_config_t  intconf)
 {
@@ -4687,7 +4687,7 @@ VL53L1_Error VL53L1::VL53L1_set_GPIO_interrupt_config_struct(
 
 
 
-VL53L1_Error VL53L1::VL53L1_get_GPIO_interrupt_config(
+VL53L1_Error VL53L1Base::VL53L1_get_GPIO_interrupt_config(
   VL53L1_DEV                      Dev,
   VL53L1_GPIO_interrupt_config_t  *pintconf)
 {
@@ -4726,7 +4726,7 @@ VL53L1_Error VL53L1::VL53L1_get_GPIO_interrupt_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_dmax_mode(
+VL53L1_Error VL53L1Base::VL53L1_set_dmax_mode(
   VL53L1_DEV               Dev,
   VL53L1_DeviceDmaxMode    dmax_mode)
 {
@@ -4746,7 +4746,7 @@ VL53L1_Error VL53L1::VL53L1_set_dmax_mode(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_dmax_mode(
+VL53L1_Error VL53L1Base::VL53L1_get_dmax_mode(
   VL53L1_DEV               Dev,
   VL53L1_DeviceDmaxMode   *pdmax_mode)
 {
@@ -4766,7 +4766,7 @@ VL53L1_Error VL53L1::VL53L1_get_dmax_mode(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_dmax_calibration_data(
+VL53L1_Error VL53L1Base::VL53L1_get_dmax_calibration_data(
   VL53L1_DEV                      Dev,
   VL53L1_DeviceDmaxMode           dmax_mode,
   uint8_t                         zone_id,
@@ -4823,7 +4823,7 @@ VL53L1_Error VL53L1::VL53L1_get_dmax_calibration_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_hist_dmax_config(
+VL53L1_Error VL53L1Base::VL53L1_set_hist_dmax_config(
   VL53L1_DEV                      Dev,
   VL53L1_hist_gen3_dmax_config_t *pdmax_cfg)
 {
@@ -4848,7 +4848,7 @@ VL53L1_Error VL53L1::VL53L1_set_hist_dmax_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_hist_dmax_config(
+VL53L1_Error VL53L1Base::VL53L1_get_hist_dmax_config(
   VL53L1_DEV                      Dev,
   VL53L1_hist_gen3_dmax_config_t *pdmax_cfg)
 {
@@ -4873,7 +4873,7 @@ VL53L1_Error VL53L1::VL53L1_get_hist_dmax_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_offset_calibration_mode(
+VL53L1_Error VL53L1Base::VL53L1_set_offset_calibration_mode(
   VL53L1_DEV                     Dev,
   VL53L1_OffsetCalibrationMode   offset_cal_mode)
 {
@@ -4894,7 +4894,7 @@ VL53L1_Error VL53L1::VL53L1_set_offset_calibration_mode(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_offset_calibration_mode(
+VL53L1_Error VL53L1Base::VL53L1_get_offset_calibration_mode(
   VL53L1_DEV                     Dev,
   VL53L1_OffsetCalibrationMode  *poffset_cal_mode)
 {
@@ -4915,7 +4915,7 @@ VL53L1_Error VL53L1::VL53L1_get_offset_calibration_mode(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_offset_correction_mode(
+VL53L1_Error VL53L1Base::VL53L1_set_offset_correction_mode(
   VL53L1_DEV                     Dev,
   VL53L1_OffsetCorrectionMode    offset_cor_mode)
 {
@@ -4936,7 +4936,7 @@ VL53L1_Error VL53L1::VL53L1_set_offset_correction_mode(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_offset_correction_mode(
+VL53L1_Error VL53L1Base::VL53L1_get_offset_correction_mode(
   VL53L1_DEV                     Dev,
   VL53L1_OffsetCorrectionMode   *poffset_cor_mode)
 {
@@ -4959,7 +4959,7 @@ VL53L1_Error VL53L1::VL53L1_get_offset_correction_mode(
 
 
 
-VL53L1_Error VL53L1::VL53L1_set_zone_calibration_data(
+VL53L1_Error VL53L1Base::VL53L1_set_zone_calibration_data(
   VL53L1_DEV                          Dev,
   VL53L1_zone_calibration_results_t  *pzone_cal)
 {
@@ -4991,7 +4991,7 @@ VL53L1_Error VL53L1::VL53L1_set_zone_calibration_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_zone_calibration_data(
+VL53L1_Error VL53L1Base::VL53L1_get_zone_calibration_data(
   VL53L1_DEV                          Dev,
   VL53L1_zone_calibration_results_t  *pzone_cal)
 {
@@ -5019,7 +5019,7 @@ VL53L1_Error VL53L1::VL53L1_get_zone_calibration_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_tuning_debug_data(
+VL53L1_Error VL53L1Base::VL53L1_get_tuning_debug_data(
   VL53L1_DEV                            Dev,
   VL53L1_tuning_parameters_t           *ptun_data)
 {
@@ -5466,7 +5466,7 @@ VL53L1_Error VL53L1::VL53L1_get_tuning_debug_data(
 
 
 
-VL53L1_Error VL53L1::VL53L1_get_tuning_parm(
+VL53L1_Error VL53L1Base::VL53L1_get_tuning_parm(
   VL53L1_DEV                     Dev,
   VL53L1_TuningParms             tuning_parm_key,
   int32_t                       *ptuning_parm_value)
@@ -6078,7 +6078,7 @@ VL53L1_Error VL53L1::VL53L1_get_tuning_parm(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_set_tuning_parm(
+VL53L1_Error VL53L1Base::VL53L1_set_tuning_parm(
   VL53L1_DEV            Dev,
   VL53L1_TuningParms    tuning_parm_key,
   int32_t               tuning_parm_value)
@@ -6702,7 +6702,7 @@ VL53L1_Error VL53L1::VL53L1_set_tuning_parm(
 
 
 
-VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_enable(
+VL53L1_Error VL53L1Base::VL53L1_dynamic_xtalk_correction_enable(
   VL53L1_DEV                          Dev
 )
 {
@@ -6722,7 +6722,7 @@ VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_enable(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_disable(
+VL53L1_Error VL53L1Base::VL53L1_dynamic_xtalk_correction_disable(
   VL53L1_DEV                          Dev
 )
 {
@@ -6742,7 +6742,7 @@ VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_disable(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_apply_enable(
+VL53L1_Error VL53L1Base::VL53L1_dynamic_xtalk_correction_apply_enable(
   VL53L1_DEV                          Dev
 )
 {
@@ -6762,7 +6762,7 @@ VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_apply_enable(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_apply_disable(
+VL53L1_Error VL53L1Base::VL53L1_dynamic_xtalk_correction_apply_disable(
   VL53L1_DEV                          Dev
 )
 {
@@ -6782,7 +6782,7 @@ VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_apply_disable(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_single_apply_enable(
+VL53L1_Error VL53L1Base::VL53L1_dynamic_xtalk_correction_single_apply_enable(
   VL53L1_DEV                          Dev
 )
 {
@@ -6802,7 +6802,7 @@ VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_single_apply_enable(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_single_apply_disable(
+VL53L1_Error VL53L1Base::VL53L1_dynamic_xtalk_correction_single_apply_disable(
   VL53L1_DEV                          Dev
 )
 {
@@ -6823,7 +6823,7 @@ VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_single_apply_disable(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_set_scalers(
+VL53L1_Error VL53L1Base::VL53L1_dynamic_xtalk_correction_set_scalers(
   VL53L1_DEV  Dev,
   int16_t   x_scaler_in,
   int16_t   y_scaler_in,
@@ -6853,7 +6853,7 @@ VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_set_scalers(
 
 
 
-VL53L1_Error VL53L1::VL53L1_get_current_xtalk_settings(
+VL53L1_Error VL53L1Base::VL53L1_get_current_xtalk_settings(
   VL53L1_DEV                          Dev,
   VL53L1_xtalk_calibration_results_t *pxtalk
 )
@@ -6887,7 +6887,7 @@ VL53L1_Error VL53L1::VL53L1_get_current_xtalk_settings(
 
 
 
-VL53L1_Error VL53L1::VL53L1_set_current_xtalk_settings(
+VL53L1_Error VL53L1Base::VL53L1_set_current_xtalk_settings(
   VL53L1_DEV                          Dev,
   VL53L1_xtalk_calibration_results_t *pxtalk
 )

--- a/src/vl53l1_api_debug.cpp
+++ b/src/vl53l1_api_debug.cpp
@@ -68,7 +68,7 @@
 #include "vl53l1_class.h"
 
 
-VL53L1_Error VL53L1::VL53L1_decode_calibration_data_buffer(
+VL53L1_Error VL53L1Base::VL53L1_decode_calibration_data_buffer(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_calibration_data_t *pdata)
@@ -89,7 +89,7 @@ VL53L1_Error VL53L1::VL53L1_decode_calibration_data_buffer(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_nvm_debug_data(
+VL53L1_Error VL53L1Base::VL53L1_get_nvm_debug_data(
   VL53L1_DEV                          Dev,
   VL53L1_decoded_nvm_data_t          *pdata)
 {
@@ -107,7 +107,7 @@ VL53L1_Error VL53L1::VL53L1_get_nvm_debug_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_histogram_debug_data(
+VL53L1_Error VL53L1Base::VL53L1_get_histogram_debug_data(
   VL53L1_DEV                          Dev,
   VL53L1_histogram_bin_data_t        *pdata)
 {
@@ -133,7 +133,7 @@ VL53L1_Error VL53L1::VL53L1_get_histogram_debug_data(
 
 
 
-VL53L1_Error VL53L1::VL53L1_get_additional_data(
+VL53L1_Error VL53L1Base::VL53L1_get_additional_data(
   VL53L1_DEV                       Dev,
   VL53L1_additional_data_t        *pdata)
 {
@@ -176,7 +176,7 @@ VL53L1_Error VL53L1::VL53L1_get_additional_data(
 
 
 
-VL53L1_Error VL53L1::VL53L1_get_xtalk_debug_data(
+VL53L1_Error VL53L1Base::VL53L1_get_xtalk_debug_data(
   VL53L1_DEV                          Dev,
   VL53L1_xtalk_debug_data_t          *pdata)
 {
@@ -220,7 +220,7 @@ VL53L1_Error VL53L1::VL53L1_get_xtalk_debug_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_offset_debug_data(
+VL53L1_Error VL53L1Base::VL53L1_get_offset_debug_data(
   VL53L1_DEV                          Dev,
   VL53L1_offset_debug_data_t         *pdata)
 {

--- a/src/vl53l1_api_preset_modes.cpp
+++ b/src/vl53l1_api_preset_modes.cpp
@@ -69,7 +69,7 @@
 
 
 
-VL53L1_Error VL53L1::VL53L1_init_refspadchar_config_struct(
+VL53L1_Error VL53L1Base::VL53L1_init_refspadchar_config_struct(
   VL53L1_refspadchar_config_t   *pdata)
 {
 
@@ -99,7 +99,7 @@ VL53L1_Error VL53L1::VL53L1_init_refspadchar_config_struct(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_init_ssc_config_struct(
+VL53L1_Error VL53L1Base::VL53L1_init_ssc_config_struct(
   VL53L1_ssc_config_t   *pdata)
 {
 
@@ -137,7 +137,7 @@ VL53L1_Error VL53L1::VL53L1_init_ssc_config_struct(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_init_xtalk_config_struct(
+VL53L1_Error VL53L1Base::VL53L1_init_xtalk_config_struct(
   VL53L1_customer_nvm_managed_t *pnvm,
   VL53L1_xtalk_config_t   *pdata)
 {
@@ -217,7 +217,7 @@ VL53L1_Error VL53L1::VL53L1_init_xtalk_config_struct(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_init_xtalk_extract_config_struct(
+VL53L1_Error VL53L1Base::VL53L1_init_xtalk_extract_config_struct(
   VL53L1_xtalkextract_config_t   *pdata)
 {
 
@@ -262,7 +262,7 @@ VL53L1_Error VL53L1::VL53L1_init_xtalk_extract_config_struct(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_init_offset_cal_config_struct(
+VL53L1_Error VL53L1Base::VL53L1_init_offset_cal_config_struct(
   VL53L1_offsetcal_config_t   *pdata)
 {
 
@@ -300,7 +300,7 @@ VL53L1_Error VL53L1::VL53L1_init_offset_cal_config_struct(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_init_zone_cal_config_struct(
+VL53L1_Error VL53L1Base::VL53L1_init_zone_cal_config_struct(
   VL53L1_zonecal_config_t   *pdata)
 {
 
@@ -337,7 +337,7 @@ VL53L1_Error VL53L1::VL53L1_init_zone_cal_config_struct(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_init_hist_post_process_config_struct(
+VL53L1_Error VL53L1Base::VL53L1_init_hist_post_process_config_struct(
   uint8_t                             xtalk_compensation_enable,
   VL53L1_hist_post_process_config_t   *pdata)
 {
@@ -455,7 +455,7 @@ VL53L1_Error VL53L1::VL53L1_init_hist_post_process_config_struct(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_init_dmax_calibration_data_struct(
+VL53L1_Error VL53L1Base::VL53L1_init_dmax_calibration_data_struct(
   VL53L1_dmax_calibration_data_t   *pdata)
 {
 
@@ -485,7 +485,7 @@ VL53L1_Error VL53L1::VL53L1_init_dmax_calibration_data_struct(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_init_tuning_parm_storage_struct(
+VL53L1_Error VL53L1Base::VL53L1_init_tuning_parm_storage_struct(
   VL53L1_tuning_parm_storage_t   *pdata)
 {
 
@@ -633,7 +633,7 @@ VL53L1_Error VL53L1::VL53L1_init_tuning_parm_storage_struct(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_init_hist_gen3_dmax_config_struct(
+VL53L1_Error VL53L1Base::VL53L1_init_hist_gen3_dmax_config_struct(
   VL53L1_hist_gen3_dmax_config_t   *pdata)
 {
 
@@ -672,7 +672,7 @@ VL53L1_Error VL53L1::VL53L1_init_hist_gen3_dmax_config_struct(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_standard_ranging(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_standard_ranging(
   VL53L1_static_config_t    *pstatic,
   VL53L1_histogram_config_t *phistogram,
   VL53L1_general_config_t   *pgeneral,
@@ -906,7 +906,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_standard_ranging(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_standard_ranging_short_range(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_standard_ranging_short_range(
   VL53L1_static_config_t    *pstatic,
   VL53L1_histogram_config_t *phistogram,
   VL53L1_general_config_t   *pgeneral,
@@ -965,7 +965,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_standard_ranging_short_range(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_standard_ranging_long_range(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_standard_ranging_long_range(
   VL53L1_static_config_t    *pstatic,
   VL53L1_histogram_config_t *phistogram,
   VL53L1_general_config_t   *pgeneral,
@@ -1024,7 +1024,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_standard_ranging_long_range(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_standard_ranging_mm1_cal(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_standard_ranging_mm1_cal(
   VL53L1_static_config_t    *pstatic,
   VL53L1_histogram_config_t *phistogram,
   VL53L1_general_config_t   *pgeneral,
@@ -1073,7 +1073,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_standard_ranging_mm1_cal(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_standard_ranging_mm2_cal(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_standard_ranging_mm2_cal(
   VL53L1_static_config_t    *pstatic,
   VL53L1_histogram_config_t *phistogram,
   VL53L1_general_config_t   *pgeneral,
@@ -1122,7 +1122,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_standard_ranging_mm2_cal(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_timed_ranging(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_timed_ranging(
 
   VL53L1_static_config_t    *pstatic,
   VL53L1_histogram_config_t *phistogram,
@@ -1187,7 +1187,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_timed_ranging(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_timed_ranging_short_range(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_timed_ranging_short_range(
 
   VL53L1_static_config_t    *pstatic,
   VL53L1_histogram_config_t *phistogram,
@@ -1253,7 +1253,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_timed_ranging_short_range(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_timed_ranging_long_range(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_timed_ranging_long_range(
 
   VL53L1_static_config_t    *pstatic,
   VL53L1_histogram_config_t *phistogram,
@@ -1320,7 +1320,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_timed_ranging_long_range(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_low_power_auto_ranging(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_low_power_auto_ranging(
 
   VL53L1_static_config_t    *pstatic,
   VL53L1_histogram_config_t *phistogram,
@@ -1365,7 +1365,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_low_power_auto_ranging(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_low_power_auto_short_ranging(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_low_power_auto_short_ranging(
 
   VL53L1_static_config_t    *pstatic,
   VL53L1_histogram_config_t *phistogram,
@@ -1410,7 +1410,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_low_power_auto_short_ranging(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_low_power_auto_long_ranging(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_low_power_auto_long_ranging(
 
   VL53L1_static_config_t    *pstatic,
   VL53L1_histogram_config_t *phistogram,
@@ -1457,7 +1457,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_low_power_auto_long_ranging(
 
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_singleshot_ranging(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_singleshot_ranging(
 
   VL53L1_static_config_t    *pstatic,
   VL53L1_histogram_config_t *phistogram,
@@ -1522,7 +1522,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_singleshot_ranging(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_ranging(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_ranging(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -1641,7 +1641,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_ranging(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_ranging_with_mm1(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_ranging_with_mm1(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -1722,7 +1722,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_ranging_with_mm1(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_ranging_with_mm2(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_ranging_with_mm2(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -1774,7 +1774,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_ranging_with_mm2(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_ranging_mm1_cal(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_ranging_mm1_cal(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -1854,7 +1854,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_ranging_mm1_cal(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_ranging_mm2_cal(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_ranging_mm2_cal(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -1905,7 +1905,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_ranging_mm2_cal(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_ranging_short_timing(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_ranging_short_timing(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -2011,7 +2011,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_ranging_short_timing(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_long_range(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_long_range(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -2133,7 +2133,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_long_range(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_long_range_mm1(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_long_range_mm1(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -2209,7 +2209,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_long_range_mm1(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_long_range_mm2(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_long_range_mm2(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -2262,7 +2262,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_long_range_mm2(
 
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_medium_range(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_medium_range(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -2384,7 +2384,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_medium_range(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_medium_range_mm1(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_medium_range_mm1(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -2458,7 +2458,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_medium_range_mm1(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_medium_range_mm2(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_medium_range_mm2(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -2510,7 +2510,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_medium_range_mm2(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_short_range(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_short_range(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -2634,7 +2634,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_short_range(
 
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_special_histogram_short_range(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_special_histogram_short_range(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -2729,7 +2729,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_special_histogram_short_range(
 
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_short_range_mm1(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_short_range_mm1(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -2806,7 +2806,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_short_range_mm1(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_short_range_mm2(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_short_range_mm2(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -2859,7 +2859,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_short_range_mm2(
 
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_characterisation(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_characterisation(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -2916,7 +2916,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_characterisation(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_xtalk_planar(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_xtalk_planar(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -3004,7 +3004,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_xtalk_planar(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_xtalk_mm1(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_xtalk_mm1(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -3121,7 +3121,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_xtalk_mm1(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_xtalk_mm2(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_xtalk_mm2(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -3171,7 +3171,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_xtalk_mm2(
 
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_multizone(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_multizone(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -3241,7 +3241,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_multizone(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_multizone_short_range(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_multizone_short_range(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -3315,7 +3315,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_multizone_short_range(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_multizone_long_range(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_multizone_long_range(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,
@@ -3390,7 +3390,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_multizone_long_range(
 
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_olt(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_olt(
   VL53L1_static_config_t    *pstatic,
   VL53L1_histogram_config_t *phistogram,
   VL53L1_general_config_t   *pgeneral,
@@ -3432,7 +3432,7 @@ VL53L1_Error VL53L1::VL53L1_preset_mode_olt(
 }
 
 
-void VL53L1::VL53L1_copy_hist_cfg_to_static_cfg(
+void VL53L1Base::VL53L1_copy_hist_cfg_to_static_cfg(
   VL53L1_histogram_config_t *phistogram,
   VL53L1_static_config_t    *pstatic,
   VL53L1_general_config_t   *pgeneral,
@@ -3508,7 +3508,7 @@ void VL53L1::VL53L1_copy_hist_cfg_to_static_cfg(
 
 }
 
-void VL53L1::VL53L1_copy_hist_bins_to_static_cfg(
+void VL53L1Base::VL53L1_copy_hist_bins_to_static_cfg(
   VL53L1_histogram_config_t *phistogram,
   VL53L1_static_config_t    *pstatic,
   VL53L1_timing_config_t    *ptiming)
@@ -3569,7 +3569,7 @@ void VL53L1::VL53L1_copy_hist_bins_to_static_cfg(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_preset_mode_histogram_ranging_ref(
+VL53L1_Error VL53L1Base::VL53L1_preset_mode_histogram_ranging_ref(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_static_config_t             *pstatic,
   VL53L1_histogram_config_t          *phistogram,

--- a/src/vl53l1_api_strings.cpp
+++ b/src/vl53l1_api_strings.cpp
@@ -65,7 +65,7 @@
 #include "vl53l1_class.h"
 
 
-VL53L1_Error VL53L1::VL53L1_get_range_status_string(
+VL53L1_Error VL53L1Base::VL53L1_get_range_status_string(
   uint8_t   RangeStatus,
   char    *pRangeStatusString)
 {
@@ -113,7 +113,7 @@ VL53L1_Error VL53L1::VL53L1_get_range_status_string(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_pal_state_string(
+VL53L1_Error VL53L1Base::VL53L1_get_pal_state_string(
   VL53L1_State PalStateCode,
   char *pPalStateString)
 {
@@ -168,7 +168,7 @@ VL53L1_Error VL53L1::VL53L1_get_pal_state_string(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_get_sequence_steps_info(
+VL53L1_Error VL53L1Base::VL53L1_get_sequence_steps_info(
   VL53L1_SequenceStepId SequenceStepId,
   char *pSequenceStepsString)
 {
@@ -221,7 +221,7 @@ VL53L1_Error VL53L1::VL53L1_get_sequence_steps_info(
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_get_limit_check_info(uint16_t LimitCheckId,
+VL53L1_Error VL53L1Base::VL53L1_get_limit_check_info(uint16_t LimitCheckId,
                                                  char *pLimitCheckString)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;

--- a/src/vl53l1_api_strings.cpp
+++ b/src/vl53l1_api_strings.cpp
@@ -222,7 +222,7 @@ VL53L1_Error VL53L1Base::VL53L1_get_sequence_steps_info(
 }
 
 VL53L1_Error VL53L1Base::VL53L1_get_limit_check_info(uint16_t LimitCheckId,
-                                                 char *pLimitCheckString)
+                                                     char *pLimitCheckString)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 

--- a/src/vl53l1_class.cpp
+++ b/src/vl53l1_class.cpp
@@ -3974,4 +3974,35 @@ VL53L1_Error VL53L1Base::VL53L1_WaitValueMaskEx(VL53L1_Dev_t *pdev, uint32_t tim
   return status;
 }
 
+VL53L1::VL53L1(TwoWire *const i2c, const int pin) : VL53L1Base(i2c), xshut(pin)
+{
+}
 
+void VL53L1::VL53L1_XshutSetLow()
+{
+  if (xshut >= 0) {
+    digitalWrite(xshut, LOW);
+  }
+
+}
+
+void VL53L1::VL53L1_XshutSetHigh()
+{
+  if (xshut >= 0) {
+    digitalWrite(xshut, HIGH);
+  }
+}
+
+void VL53L1::VL53L1_XshutDeinitialize()
+{
+  if (xshut >= 0) {
+    pinMode(xshut, INPUT);
+  }
+}
+
+void VL53L1::VL53L1_XshutInitialize()
+{
+  if (xshut >= 0) {
+    pinMode(xshut, OUTPUT);
+  }
+}

--- a/src/vl53l1_class.cpp
+++ b/src/vl53l1_class.cpp
@@ -110,7 +110,7 @@ static int32_t BDTable[VL53L1_TUNING_MAX_TUNABLE_KEY] = {
 };
 
 
-VL53L1_Error VL53L1::SingleTargetXTalkCalibration(VL53L1_DEV Dev)
+VL53L1_Error VL53L1Base::SingleTargetXTalkCalibration(VL53L1_DEV Dev)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -248,7 +248,7 @@ ENDFUNC:
 }
 
 
-VL53L1_Error VL53L1::CheckValidRectRoi(VL53L1_UserRoi_t ROI)
+VL53L1_Error VL53L1Base::CheckValidRectRoi(VL53L1_UserRoi_t ROI)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -268,7 +268,7 @@ VL53L1_Error VL53L1::CheckValidRectRoi(VL53L1_UserRoi_t ROI)
   return Status;
 }
 
-VL53L1_GPIO_Interrupt_Mode VL53L1::ConvertModeToLLD(VL53L1_Error *pStatus, VL53L1_ThresholdMode CrossMode)
+VL53L1_GPIO_Interrupt_Mode VL53L1Base::ConvertModeToLLD(VL53L1_Error *pStatus, VL53L1_ThresholdMode CrossMode)
 {
   VL53L1_GPIO_Interrupt_Mode Mode;
 
@@ -293,7 +293,7 @@ VL53L1_GPIO_Interrupt_Mode VL53L1::ConvertModeToLLD(VL53L1_Error *pStatus, VL53L
   return Mode;
 }
 
-VL53L1_ThresholdMode VL53L1::ConvertModeFromLLD(VL53L1_Error *pStatus, VL53L1_GPIO_Interrupt_Mode CrossMode)
+VL53L1_ThresholdMode VL53L1Base::ConvertModeFromLLD(VL53L1_Error *pStatus, VL53L1_GPIO_Interrupt_Mode CrossMode)
 {
   VL53L1_ThresholdMode Mode;
 
@@ -320,7 +320,7 @@ VL53L1_ThresholdMode VL53L1::ConvertModeFromLLD(VL53L1_Error *pStatus, VL53L1_GP
 
 
 
-VL53L1_Error VL53L1::VL53L1_GetVersion(VL53L1_Version_t *pVersion)
+VL53L1_Error VL53L1Base::VL53L1_GetVersion(VL53L1_Version_t *pVersion)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -336,7 +336,7 @@ VL53L1_Error VL53L1::VL53L1_GetVersion(VL53L1_Version_t *pVersion)
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetProductRevision(uint8_t *pProductRevisionMajor, uint8_t *pProductRevisionMinor)
+VL53L1_Error VL53L1Base::VL53L1_GetProductRevision(uint8_t *pProductRevisionMajor, uint8_t *pProductRevisionMinor)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint8_t revision_id;
@@ -354,7 +354,7 @@ VL53L1_Error VL53L1::VL53L1_GetProductRevision(uint8_t *pProductRevisionMajor, u
 
 }
 
-VL53L1_Error VL53L1::VL53L1_GetDeviceInfo(VL53L1_DeviceInfo_t *pVL53L1_DeviceInfo)
+VL53L1_Error VL53L1Base::VL53L1_GetDeviceInfo(VL53L1_DeviceInfo_t *pVL53L1_DeviceInfo)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint8_t revision_id;
@@ -399,7 +399,7 @@ VL53L1_Error VL53L1::VL53L1_GetDeviceInfo(VL53L1_DeviceInfo_t *pVL53L1_DeviceInf
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetUID(uint64_t *pUid)
+VL53L1_Error VL53L1Base::VL53L1_GetUID(uint64_t *pUid)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint8_t fmtdata[8];
@@ -416,7 +416,7 @@ VL53L1_Error VL53L1::VL53L1_GetUID(uint64_t *pUid)
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetRangeStatusString(uint8_t RangeStatus, char *pRangeStatusString)
+VL53L1_Error VL53L1Base::VL53L1_GetRangeStatusString(uint8_t RangeStatus, char *pRangeStatusString)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -429,7 +429,7 @@ VL53L1_Error VL53L1::VL53L1_GetRangeStatusString(uint8_t RangeStatus, char *pRan
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetPalErrorString(VL53L1_Error PalErrorCode, char *pPalErrorString)
+VL53L1_Error VL53L1Base::VL53L1_GetPalErrorString(VL53L1_Error PalErrorCode, char *pPalErrorString)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -441,7 +441,7 @@ VL53L1_Error VL53L1::VL53L1_GetPalErrorString(VL53L1_Error PalErrorCode, char *p
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetPalStateString(VL53L1_State PalStateCode, char *pPalStateString)
+VL53L1_Error VL53L1Base::VL53L1_GetPalStateString(VL53L1_State PalStateCode, char *pPalStateString)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -453,7 +453,7 @@ VL53L1_Error VL53L1::VL53L1_GetPalStateString(VL53L1_State PalStateCode, char *p
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetPalState(VL53L1_State *pPalState)
+VL53L1_Error VL53L1Base::VL53L1_GetPalState(VL53L1_State *pPalState)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -466,7 +466,7 @@ VL53L1_Error VL53L1::VL53L1_GetPalState(VL53L1_State *pPalState)
 }
 
 
-VL53L1_Error VL53L1::VL53L1_SetDeviceAddress(uint8_t DeviceAddress)
+VL53L1_Error VL53L1Base::VL53L1_SetDeviceAddress(uint8_t DeviceAddress)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -483,7 +483,7 @@ VL53L1_Error VL53L1::VL53L1_SetDeviceAddress(uint8_t DeviceAddress)
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_DataInit()
+VL53L1_Error VL53L1Base::VL53L1_DataInit()
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint8_t i;
@@ -539,7 +539,7 @@ VL53L1_Error VL53L1::VL53L1_DataInit()
 }
 
 
-VL53L1_Error VL53L1::VL53L1_StaticInit()
+VL53L1_Error VL53L1Base::VL53L1_StaticInit()
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint8_t  measurement_mode;
@@ -559,7 +559,7 @@ VL53L1_Error VL53L1::VL53L1_StaticInit()
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_WaitDeviceBooted()
+VL53L1_Error VL53L1Base::VL53L1_WaitDeviceBooted()
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -575,7 +575,7 @@ VL53L1_Error VL53L1::VL53L1_WaitDeviceBooted()
 
 
 
-VL53L1_Error VL53L1::ComputeDevicePresetMode(VL53L1_PresetModes PresetMode, VL53L1_DistanceModes DistanceMode, VL53L1_DevicePresetModes *pDevicePresetMode)
+VL53L1_Error VL53L1Base::ComputeDevicePresetMode(VL53L1_PresetModes PresetMode, VL53L1_DistanceModes DistanceMode, VL53L1_DevicePresetModes *pDevicePresetMode)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -659,7 +659,7 @@ VL53L1_Error VL53L1::ComputeDevicePresetMode(VL53L1_PresetModes PresetMode, VL53
   return Status;
 }
 
-VL53L1_Error VL53L1::SetPresetMode(VL53L1_DEV Dev, VL53L1_PresetModes PresetMode, VL53L1_DistanceModes DistanceMode, uint32_t inter_measurement_period_ms)
+VL53L1_Error VL53L1Base::SetPresetMode(VL53L1_DEV Dev, VL53L1_PresetModes PresetMode, VL53L1_DistanceModes DistanceMode, uint32_t inter_measurement_period_ms)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_DevicePresetModes   device_preset_mode;
@@ -713,7 +713,7 @@ VL53L1_Error VL53L1::SetPresetMode(VL53L1_DEV Dev, VL53L1_PresetModes PresetMode
 }
 
 
-VL53L1_Error VL53L1::VL53L1_SetPresetMode(VL53L1_PresetModes PresetMode)
+VL53L1_Error VL53L1Base::VL53L1_SetPresetMode(VL53L1_PresetModes PresetMode)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_DistanceModes DistanceMode = VL53L1_DISTANCEMODE_LONG;
@@ -751,7 +751,7 @@ VL53L1_Error VL53L1::VL53L1_SetPresetMode(VL53L1_PresetModes PresetMode)
 }
 
 
-VL53L1_Error VL53L1::VL53L1_GetPresetMode(VL53L1_PresetModes *pPresetMode)
+VL53L1_Error VL53L1Base::VL53L1_GetPresetMode(VL53L1_PresetModes *pPresetMode)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -763,7 +763,7 @@ VL53L1_Error VL53L1::VL53L1_GetPresetMode(VL53L1_PresetModes *pPresetMode)
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_SetDistanceMode(VL53L1_DistanceModes DistanceMode)
+VL53L1_Error VL53L1Base::VL53L1_SetDistanceMode(VL53L1_DistanceModes DistanceMode)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_PresetModes PresetMode;
@@ -826,7 +826,7 @@ VL53L1_Error VL53L1::VL53L1_SetDistanceMode(VL53L1_DistanceModes DistanceMode)
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetDistanceMode(VL53L1_DistanceModes *pDistanceMode)
+VL53L1_Error VL53L1Base::VL53L1_GetDistanceMode(VL53L1_DistanceModes *pDistanceMode)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -838,7 +838,7 @@ VL53L1_Error VL53L1::VL53L1_GetDistanceMode(VL53L1_DistanceModes *pDistanceMode)
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_SetOutputMode(VL53L1_OutputModes OutputMode)
+VL53L1_Error VL53L1Base::VL53L1_SetOutputMode(VL53L1_OutputModes OutputMode)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -855,7 +855,7 @@ VL53L1_Error VL53L1::VL53L1_SetOutputMode(VL53L1_OutputModes OutputMode)
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetOutputMode(VL53L1_OutputModes *pOutputMode)
+VL53L1_Error VL53L1Base::VL53L1_GetOutputMode(VL53L1_OutputModes *pOutputMode)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -869,7 +869,7 @@ VL53L1_Error VL53L1::VL53L1_GetOutputMode(VL53L1_OutputModes *pOutputMode)
 
 
 
-VL53L1_Error VL53L1::VL53L1_SetMeasurementTimingBudgetMicroSeconds(uint32_t MeasurementTimingBudgetMicroSeconds)
+VL53L1_Error VL53L1Base::VL53L1_SetMeasurementTimingBudgetMicroSeconds(uint32_t MeasurementTimingBudgetMicroSeconds)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint8_t Mm1Enabled;
@@ -997,7 +997,7 @@ VL53L1_Error VL53L1::VL53L1_SetMeasurementTimingBudgetMicroSeconds(uint32_t Meas
 }
 
 
-VL53L1_Error VL53L1::VL53L1_GetMeasurementTimingBudgetMicroSeconds(uint32_t *pMeasurementTimingBudgetMicroSeconds)
+VL53L1_Error VL53L1Base::VL53L1_GetMeasurementTimingBudgetMicroSeconds(uint32_t *pMeasurementTimingBudgetMicroSeconds)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint8_t Mm1Enabled = 0;
@@ -1091,7 +1091,7 @@ VL53L1_Error VL53L1::VL53L1_GetMeasurementTimingBudgetMicroSeconds(uint32_t *pMe
 
 
 
-VL53L1_Error VL53L1::VL53L1_SetInterMeasurementPeriodMilliSeconds(uint32_t InterMeasurementPeriodMilliSeconds)
+VL53L1_Error VL53L1Base::VL53L1_SetInterMeasurementPeriodMilliSeconds(uint32_t InterMeasurementPeriodMilliSeconds)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint32_t adjustedIMP;
@@ -1109,7 +1109,7 @@ VL53L1_Error VL53L1::VL53L1_SetInterMeasurementPeriodMilliSeconds(uint32_t Inter
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetInterMeasurementPeriodMilliSeconds(uint32_t *pInterMeasurementPeriodMilliSeconds)
+VL53L1_Error VL53L1Base::VL53L1_GetInterMeasurementPeriodMilliSeconds(uint32_t *pInterMeasurementPeriodMilliSeconds)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint32_t adjustedIMP;
@@ -1126,7 +1126,7 @@ VL53L1_Error VL53L1::VL53L1_GetInterMeasurementPeriodMilliSeconds(uint32_t *pInt
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_SetDmaxReflectance(FixPoint1616_t DmaxReflectance)
+VL53L1_Error VL53L1Base::VL53L1_SetDmaxReflectance(FixPoint1616_t DmaxReflectance)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_dmax_reflectance_array_t dmax_reflectances;
@@ -1153,7 +1153,7 @@ VL53L1_Error VL53L1::VL53L1_SetDmaxReflectance(FixPoint1616_t DmaxReflectance)
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetDmaxReflectance(FixPoint1616_t *pDmaxReflectance)
+VL53L1_Error VL53L1Base::VL53L1_GetDmaxReflectance(FixPoint1616_t *pDmaxReflectance)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_dmax_reflectance_array_t dmax_reflectances;
@@ -1172,7 +1172,7 @@ VL53L1_Error VL53L1::VL53L1_GetDmaxReflectance(FixPoint1616_t *pDmaxReflectance)
 }
 
 
-VL53L1_Error VL53L1::VL53L1_SetDmaxMode(VL53L1_DeviceDmaxModes DmaxMode)
+VL53L1_Error VL53L1Base::VL53L1_SetDmaxMode(VL53L1_DeviceDmaxModes DmaxMode)
 {
 
   VL53L1_Error  Status = VL53L1_ERROR_NONE;
@@ -1203,7 +1203,7 @@ VL53L1_Error VL53L1::VL53L1_SetDmaxMode(VL53L1_DeviceDmaxModes DmaxMode)
 }
 
 
-VL53L1_Error VL53L1::VL53L1_GetDmaxMode(VL53L1_DeviceDmaxModes *pDmaxMode)
+VL53L1_Error VL53L1Base::VL53L1_GetDmaxMode(VL53L1_DeviceDmaxModes *pDmaxMode)
 {
   VL53L1_Error  Status = VL53L1_ERROR_NONE;
   VL53L1_DeviceDmaxMode dmax_mode;
@@ -1239,7 +1239,7 @@ VL53L1_Error VL53L1::VL53L1_GetDmaxMode(VL53L1_DeviceDmaxModes *pDmaxMode)
 
 
 
-VL53L1_Error VL53L1::VL53L1_GetNumberOfLimitCheck(uint16_t *pNumberOfLimitCheck)
+VL53L1_Error VL53L1Base::VL53L1_GetNumberOfLimitCheck(uint16_t *pNumberOfLimitCheck)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -1251,7 +1251,7 @@ VL53L1_Error VL53L1::VL53L1_GetNumberOfLimitCheck(uint16_t *pNumberOfLimitCheck)
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetLimitCheckInfo(uint16_t LimitCheckId, char *pLimitCheckString)
+VL53L1_Error VL53L1Base::VL53L1_GetLimitCheckInfo(uint16_t LimitCheckId, char *pLimitCheckString)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -1264,7 +1264,7 @@ VL53L1_Error VL53L1::VL53L1_GetLimitCheckInfo(uint16_t LimitCheckId, char *pLimi
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetLimitCheckStatus(uint16_t LimitCheckId, uint8_t *pLimitCheckStatus)
+VL53L1_Error VL53L1Base::VL53L1_GetLimitCheckStatus(uint16_t LimitCheckId, uint8_t *pLimitCheckStatus)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint8_t Temp8;
@@ -1283,7 +1283,7 @@ VL53L1_Error VL53L1::VL53L1_GetLimitCheckStatus(uint16_t LimitCheckId, uint8_t *
   return Status;
 }
 
-VL53L1_Error VL53L1::SetLimitValue(VL53L1_DEV Dev, uint16_t LimitCheckId, FixPoint1616_t value)
+VL53L1_Error VL53L1Base::SetLimitValue(VL53L1_DEV Dev, uint16_t LimitCheckId, FixPoint1616_t value)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint16_t tmpuint16;
@@ -1308,7 +1308,7 @@ VL53L1_Error VL53L1::SetLimitValue(VL53L1_DEV Dev, uint16_t LimitCheckId, FixPoi
 }
 
 
-VL53L1_Error VL53L1::VL53L1_SetLimitCheckEnable(uint16_t LimitCheckId, uint8_t LimitCheckEnable)
+VL53L1_Error VL53L1Base::VL53L1_SetLimitCheckEnable(uint16_t LimitCheckId, uint8_t LimitCheckEnable)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   FixPoint1616_t TempFix1616 = 0;
@@ -1341,7 +1341,7 @@ VL53L1_Error VL53L1::VL53L1_SetLimitCheckEnable(uint16_t LimitCheckId, uint8_t L
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetLimitCheckEnable(uint16_t LimitCheckId, uint8_t *pLimitCheckEnable)
+VL53L1_Error VL53L1Base::VL53L1_GetLimitCheckEnable(uint16_t LimitCheckId, uint8_t *pLimitCheckEnable)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint8_t Temp8;
@@ -1362,7 +1362,7 @@ VL53L1_Error VL53L1::VL53L1_GetLimitCheckEnable(uint16_t LimitCheckId, uint8_t *
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_SetLimitCheckValue(uint16_t LimitCheckId, FixPoint1616_t LimitCheckValue)
+VL53L1_Error VL53L1Base::VL53L1_SetLimitCheckValue(uint16_t LimitCheckId, FixPoint1616_t LimitCheckValue)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint8_t LimitChecksEnable;
@@ -1398,7 +1398,7 @@ VL53L1_Error VL53L1::VL53L1_SetLimitCheckValue(uint16_t LimitCheckId, FixPoint16
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetLimitCheckValue(uint16_t LimitCheckId, FixPoint1616_t *pLimitCheckValue)
+VL53L1_Error VL53L1Base::VL53L1_GetLimitCheckValue(uint16_t LimitCheckId, FixPoint1616_t *pLimitCheckValue)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint16_t MinCountRate;
@@ -1444,7 +1444,7 @@ VL53L1_Error VL53L1::VL53L1_GetLimitCheckValue(uint16_t LimitCheckId, FixPoint16
 
 }
 
-VL53L1_Error VL53L1::VL53L1_GetLimitCheckCurrent(uint16_t LimitCheckId, FixPoint1616_t *pLimitCheckCurrent)
+VL53L1_Error VL53L1Base::VL53L1_GetLimitCheckCurrent(uint16_t LimitCheckId, FixPoint1616_t *pLimitCheckCurrent)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   FixPoint1616_t TempFix1616 = 0;
@@ -1471,7 +1471,7 @@ VL53L1_Error VL53L1::VL53L1_GetLimitCheckCurrent(uint16_t LimitCheckId, FixPoint
 
 
 
-VL53L1_Error VL53L1::VL53L1_GetMaxNumberOfROI(uint8_t *pMaxNumberOfROI)
+VL53L1_Error VL53L1Base::VL53L1_GetMaxNumberOfROI(uint8_t *pMaxNumberOfROI)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_PresetModes PresetMode;
@@ -1491,7 +1491,7 @@ VL53L1_Error VL53L1::VL53L1_GetMaxNumberOfROI(uint8_t *pMaxNumberOfROI)
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_SetROI(VL53L1_RoiConfig_t *pRoiConfig)
+VL53L1_Error VL53L1Base::VL53L1_SetROI(VL53L1_RoiConfig_t *pRoiConfig)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_PresetModes PresetMode;
@@ -1557,7 +1557,7 @@ VL53L1_Error VL53L1::VL53L1_SetROI(VL53L1_RoiConfig_t *pRoiConfig)
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetROI(VL53L1_RoiConfig_t *pRoiConfig)
+VL53L1_Error VL53L1Base::VL53L1_GetROI(VL53L1_RoiConfig_t *pRoiConfig)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_zone_config_t      zone_cfg;
@@ -1598,7 +1598,7 @@ VL53L1_Error VL53L1::VL53L1_GetROI(VL53L1_RoiConfig_t *pRoiConfig)
 
 
 
-VL53L1_Error VL53L1::VL53L1_GetNumberOfSequenceSteps(uint8_t *pNumberOfSequenceSteps)
+VL53L1_Error VL53L1Base::VL53L1_GetNumberOfSequenceSteps(uint8_t *pNumberOfSequenceSteps)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -1612,7 +1612,7 @@ VL53L1_Error VL53L1::VL53L1_GetNumberOfSequenceSteps(uint8_t *pNumberOfSequenceS
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetSequenceStepsInfo(VL53L1_SequenceStepId SequenceStepId, char *pSequenceStepsString)
+VL53L1_Error VL53L1Base::VL53L1_GetSequenceStepsInfo(VL53L1_SequenceStepId SequenceStepId, char *pSequenceStepsString)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -1627,7 +1627,7 @@ VL53L1_Error VL53L1::VL53L1_GetSequenceStepsInfo(VL53L1_SequenceStepId SequenceS
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_SetSequenceStepEnable(VL53L1_SequenceStepId SequenceStepId, uint8_t SequenceStepEnabled)
+VL53L1_Error VL53L1Base::VL53L1_SetSequenceStepEnable(VL53L1_SequenceStepId SequenceStepId, uint8_t SequenceStepEnabled)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint32_t MeasurementTimingBudgetMicroSeconds;
@@ -1656,7 +1656,7 @@ VL53L1_Error VL53L1::VL53L1_SetSequenceStepEnable(VL53L1_SequenceStepId Sequence
 }
 
 
-VL53L1_Error VL53L1::VL53L1_GetSequenceStepEnable(VL53L1_SequenceStepId SequenceStepId, uint8_t *pSequenceStepEnabled)
+VL53L1_Error VL53L1Base::VL53L1_GetSequenceStepEnable(VL53L1_SequenceStepId SequenceStepId, uint8_t *pSequenceStepEnabled)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -1679,7 +1679,7 @@ VL53L1_Error VL53L1::VL53L1_GetSequenceStepEnable(VL53L1_SequenceStepId Sequence
 
 
 
-VL53L1_Error VL53L1::VL53L1_StartMeasurement()
+VL53L1_Error VL53L1Base::VL53L1_StartMeasurement()
 {
 #define TIMED_MODE_TIMING_GUARD_MILLISECONDS 4
   VL53L1_Error Status = VL53L1_ERROR_NONE;
@@ -1740,7 +1740,7 @@ VL53L1_Error VL53L1::VL53L1_StartMeasurement()
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_StopMeasurement()
+VL53L1_Error VL53L1Base::VL53L1_StopMeasurement()
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -1758,7 +1758,7 @@ VL53L1_Error VL53L1::VL53L1_StopMeasurement()
 }
 
 
-VL53L1_Error VL53L1::VL53L1_ClearInterruptAndStartMeasurement()
+VL53L1_Error VL53L1Base::VL53L1_ClearInterruptAndStartMeasurement()
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint8_t DeviceMeasurementMode;
@@ -1775,7 +1775,7 @@ VL53L1_Error VL53L1::VL53L1_ClearInterruptAndStartMeasurement()
 }
 
 
-VL53L1_Error VL53L1::VL53L1_GetMeasurementDataReady(uint8_t *pMeasurementDataReady)
+VL53L1_Error VL53L1Base::VL53L1_GetMeasurementDataReady(uint8_t *pMeasurementDataReady)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -1787,7 +1787,7 @@ VL53L1_Error VL53L1::VL53L1_GetMeasurementDataReady(uint8_t *pMeasurementDataRea
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_WaitMeasurementDataReady()
+VL53L1_Error VL53L1Base::VL53L1_WaitMeasurementDataReady()
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -1802,7 +1802,7 @@ VL53L1_Error VL53L1::VL53L1_WaitMeasurementDataReady()
   return Status;
 }
 
-void VL53L1::GenNewPresetMode(int16_t RefRange, VL53L1_DistanceModes InternalDistanceMode, VL53L1_DistanceModes *pNewDistanceMode)
+void VL53L1Base::GenNewPresetMode(int16_t RefRange, VL53L1_DistanceModes InternalDistanceMode, VL53L1_DistanceModes *pNewDistanceMode)
 {
   uint16_t HRLI = 600;
   uint16_t HRLH = 700;
@@ -1837,7 +1837,7 @@ void VL53L1::GenNewPresetMode(int16_t RefRange, VL53L1_DistanceModes InternalDis
   }
 }
 
-void VL53L1::CheckAndChangeDistanceMode(VL53L1_DEV Dev, VL53L1_TargetRangeData_t *pRangeData, int16_t Ambient100DmaxMm, VL53L1_DistanceModes *pNewDistanceMode)
+void VL53L1Base::CheckAndChangeDistanceMode(VL53L1_DEV Dev, VL53L1_TargetRangeData_t *pRangeData, int16_t Ambient100DmaxMm, VL53L1_DistanceModes *pNewDistanceMode)
 {
   VL53L1_DistanceModes DistanceMode;
   uint8_t RangeStatus = pRangeData->RangeStatus;
@@ -1884,7 +1884,7 @@ void VL53L1::CheckAndChangeDistanceMode(VL53L1_DEV Dev, VL53L1_TargetRangeData_t
   }
 }
 
-uint8_t VL53L1::ComputeRQL(uint8_t active_results, uint8_t FilteredRangeStatus, VL53L1_range_data_t *presults_data)
+uint8_t VL53L1Base::ComputeRQL(uint8_t active_results, uint8_t FilteredRangeStatus, VL53L1_range_data_t *presults_data)
 {
   int16_t T_Wide = 150;
   int16_t SRL = 300;
@@ -1934,7 +1934,7 @@ uint8_t VL53L1::ComputeRQL(uint8_t active_results, uint8_t FilteredRangeStatus, 
 }
 
 
-uint8_t VL53L1::ConvertStatusLite(uint8_t FilteredRangeStatus)
+uint8_t VL53L1Base::ConvertStatusLite(uint8_t FilteredRangeStatus)
 {
   uint8_t RangeStatus;
 
@@ -1974,7 +1974,7 @@ uint8_t VL53L1::ConvertStatusLite(uint8_t FilteredRangeStatus)
 }
 
 
-uint8_t VL53L1::ConvertStatusHisto(uint8_t FilteredRangeStatus)
+uint8_t VL53L1Base::ConvertStatusHisto(uint8_t FilteredRangeStatus)
 {
   uint8_t RangeStatus;
 
@@ -2010,7 +2010,7 @@ uint8_t VL53L1::ConvertStatusHisto(uint8_t FilteredRangeStatus)
   return RangeStatus;
 }
 
-VL53L1_Error VL53L1::SetSimpleData(VL53L1_DEV Dev, uint8_t active_results, uint8_t device_status, VL53L1_range_data_t *presults_data, VL53L1_RangingMeasurementData_t *pRangeData)
+VL53L1_Error VL53L1Base::SetSimpleData(VL53L1_DEV Dev, uint8_t active_results, uint8_t device_status, VL53L1_range_data_t *presults_data, VL53L1_RangingMeasurementData_t *pRangeData)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint8_t FilteredRangeStatus;
@@ -2141,7 +2141,7 @@ VL53L1_Error VL53L1::SetSimpleData(VL53L1_DEV Dev, uint8_t active_results, uint8
   return Status;
 }
 
-VL53L1_Error VL53L1::SetTargetData(VL53L1_DEV Dev, uint8_t active_results, uint8_t device_status, VL53L1_range_data_t *presults_data, VL53L1_TargetRangeData_t *pRangeData)
+VL53L1_Error VL53L1Base::SetTargetData(VL53L1_DEV Dev, uint8_t active_results, uint8_t device_status, VL53L1_range_data_t *presults_data, VL53L1_TargetRangeData_t *pRangeData)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   uint8_t FilteredRangeStatus;
@@ -2280,7 +2280,7 @@ VL53L1_Error VL53L1::SetTargetData(VL53L1_DEV Dev, uint8_t active_results, uint8
   return Status;
 }
 
-uint8_t VL53L1::GetOutputDataIndex(VL53L1_DEV Dev, VL53L1_range_results_t *presults)
+uint8_t VL53L1Base::GetOutputDataIndex(VL53L1_DEV Dev, VL53L1_range_results_t *presults)
 {
   uint8_t i;
   uint8_t index = 0;
@@ -2304,7 +2304,7 @@ uint8_t VL53L1::GetOutputDataIndex(VL53L1_DEV Dev, VL53L1_range_results_t *presu
   return index;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetRangingMeasurementData(VL53L1_RangingMeasurementData_t *pRangingMeasurementData)
+VL53L1_Error VL53L1Base::VL53L1_GetRangingMeasurementData(VL53L1_RangingMeasurementData_t *pRangingMeasurementData)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_LLDriverData_t *pdev =
@@ -2352,7 +2352,7 @@ VL53L1_Error VL53L1::VL53L1_GetRangingMeasurementData(VL53L1_RangingMeasurementD
   return Status;
 }
 
-VL53L1_Error VL53L1::SetMeasurementData(VL53L1_DEV Dev, VL53L1_range_results_t *presults, VL53L1_MultiRangingData_t *pMultiRangingData)
+VL53L1_Error VL53L1Base::SetMeasurementData(VL53L1_DEV Dev, VL53L1_range_results_t *presults, VL53L1_MultiRangingData_t *pMultiRangingData)
 {
   uint8_t i;
   uint8_t iteration;
@@ -2419,7 +2419,7 @@ VL53L1_Error VL53L1::SetMeasurementData(VL53L1_DEV Dev, VL53L1_range_results_t *
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetMultiRangingData(VL53L1_MultiRangingData_t *pMultiRangingData)
+VL53L1_Error VL53L1Base::VL53L1_GetMultiRangingData(VL53L1_MultiRangingData_t *pMultiRangingData)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_LLDriverData_t *pdev =
@@ -2465,7 +2465,7 @@ VL53L1_Error VL53L1::VL53L1_GetMultiRangingData(VL53L1_MultiRangingData_t *pMult
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetAdditionalData(VL53L1_AdditionalData_t *pAdditionalData)
+VL53L1_Error VL53L1Base::VL53L1_GetAdditionalData(VL53L1_AdditionalData_t *pAdditionalData)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -2482,7 +2482,7 @@ VL53L1_Error VL53L1::VL53L1_GetAdditionalData(VL53L1_AdditionalData_t *pAddition
 
 
 
-VL53L1_Error VL53L1::VL53L1_SetTuningParameter(uint16_t TuningParameterId, int32_t TuningParameterValue)
+VL53L1_Error VL53L1Base::VL53L1_SetTuningParameter(uint16_t TuningParameterId, int32_t TuningParameterValue)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -2509,7 +2509,7 @@ VL53L1_Error VL53L1::VL53L1_SetTuningParameter(uint16_t TuningParameterId, int32
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetTuningParameter(uint16_t TuningParameterId, int32_t *pTuningParameterValue)
+VL53L1_Error VL53L1Base::VL53L1_GetTuningParameter(uint16_t TuningParameterId, int32_t *pTuningParameterValue)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -2532,7 +2532,7 @@ VL53L1_Error VL53L1::VL53L1_GetTuningParameter(uint16_t TuningParameterId, int32
 }
 
 
-VL53L1_Error VL53L1::VL53L1_PerformRefSpadManagement()
+VL53L1_Error VL53L1Base::VL53L1_PerformRefSpadManagement()
 {
 #ifdef VL53L1_NOCALIB
   VL53L1_Error Status = VL53L1_ERROR_NOT_SUPPORTED;
@@ -2610,7 +2610,7 @@ VL53L1_Error VL53L1::VL53L1_PerformRefSpadManagement()
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_SmudgeCorrectionEnable(VL53L1_SmudgeCorrectionModes Mode)
+VL53L1_Error VL53L1Base::VL53L1_SmudgeCorrectionEnable(VL53L1_SmudgeCorrectionModes Mode)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_Error s1 = VL53L1_ERROR_NONE;
@@ -2659,7 +2659,7 @@ VL53L1_Error VL53L1::VL53L1_SmudgeCorrectionEnable(VL53L1_SmudgeCorrectionModes 
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_SetXTalkCompensationEnable(uint8_t XTalkCompensationEnable)
+VL53L1_Error VL53L1Base::VL53L1_SetXTalkCompensationEnable(uint8_t XTalkCompensationEnable)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -2676,7 +2676,7 @@ VL53L1_Error VL53L1::VL53L1_SetXTalkCompensationEnable(uint8_t XTalkCompensation
 }
 
 
-VL53L1_Error VL53L1::VL53L1_GetXTalkCompensationEnable(uint8_t *pXTalkCompensationEnable)
+VL53L1_Error VL53L1Base::VL53L1_GetXTalkCompensationEnable(uint8_t *pXTalkCompensationEnable)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -2691,7 +2691,7 @@ VL53L1_Error VL53L1::VL53L1_GetXTalkCompensationEnable(uint8_t *pXTalkCompensati
 }
 
 
-VL53L1_Error VL53L1::VL53L1_PerformXTalkCalibration(uint8_t CalibrationOption)
+VL53L1_Error VL53L1Base::VL53L1_PerformXTalkCalibration(uint8_t CalibrationOption)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_Error UStatus;
@@ -2784,7 +2784,7 @@ VL53L1_Error VL53L1::VL53L1_PerformXTalkCalibration(uint8_t CalibrationOption)
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_SetOffsetCalibrationMode(VL53L1_OffsetCalibrationModes OffsetCalibrationMode)
+VL53L1_Error VL53L1Base::VL53L1_SetOffsetCalibrationMode(VL53L1_OffsetCalibrationModes OffsetCalibrationMode)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_OffsetCalibrationMode   offset_cal_mode;
@@ -2814,7 +2814,7 @@ VL53L1_Error VL53L1::VL53L1_SetOffsetCalibrationMode(VL53L1_OffsetCalibrationMod
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_SetOffsetCorrectionMode(VL53L1_OffsetCorrectionModes OffsetCorrectionMode)
+VL53L1_Error VL53L1Base::VL53L1_SetOffsetCorrectionMode(VL53L1_OffsetCorrectionModes OffsetCorrectionMode)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_OffsetCorrectionMode   offset_cor_mode;
@@ -2844,7 +2844,7 @@ VL53L1_Error VL53L1::VL53L1_SetOffsetCorrectionMode(VL53L1_OffsetCorrectionModes
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_PerformOffsetCalibration(int32_t CalDistanceMilliMeter, FixPoint1616_t CalReflectancePercent)
+VL53L1_Error VL53L1Base::VL53L1_PerformOffsetCalibration(int32_t CalDistanceMilliMeter, FixPoint1616_t CalReflectancePercent)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_Error UnfilteredStatus;
@@ -2906,7 +2906,7 @@ VL53L1_Error VL53L1::VL53L1_PerformOffsetCalibration(int32_t CalDistanceMilliMet
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_PerformOffsetSimpleCalibration(int32_t CalDistanceMilliMeter)
+VL53L1_Error VL53L1Base::VL53L1_PerformOffsetSimpleCalibration(int32_t CalDistanceMilliMeter)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   int32_t sum_ranging;
@@ -3007,7 +3007,7 @@ VL53L1_Error VL53L1::VL53L1_PerformOffsetSimpleCalibration(int32_t CalDistanceMi
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_PerformOffsetZeroDistanceCalibration()
+VL53L1_Error VL53L1Base::VL53L1_PerformOffsetZeroDistanceCalibration()
 {
 #define START_OFFSET 50
   VL53L1_Error Status = VL53L1_ERROR_NONE;
@@ -3099,7 +3099,7 @@ VL53L1_Error VL53L1::VL53L1_PerformOffsetZeroDistanceCalibration()
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_SetCalibrationData(VL53L1_CalibrationData_t *pCalibrationData)
+VL53L1_Error VL53L1Base::VL53L1_SetCalibrationData(VL53L1_CalibrationData_t *pCalibrationData)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_CustomerNvmManaged_t          *pC;
@@ -3230,7 +3230,7 @@ ENDFUNC:
 
 }
 
-VL53L1_Error VL53L1::VL53L1_GetCalibrationData(VL53L1_CalibrationData_t  *pCalibrationData)
+VL53L1_Error VL53L1Base::VL53L1_GetCalibrationData(VL53L1_CalibrationData_t  *pCalibrationData)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_calibration_data_t      cal_data;
@@ -3362,7 +3362,7 @@ ENDFUNC:
 }
 
 
-VL53L1_Error VL53L1::VL53L1_SetZoneCalibrationData(VL53L1_ZoneCalibrationData_t *pZoneCalibrationData)
+VL53L1_Error VL53L1Base::VL53L1_SetZoneCalibrationData(VL53L1_ZoneCalibrationData_t *pZoneCalibrationData)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -3375,7 +3375,7 @@ VL53L1_Error VL53L1::VL53L1_SetZoneCalibrationData(VL53L1_ZoneCalibrationData_t 
 
 }
 
-VL53L1_Error VL53L1::VL53L1_GetZoneCalibrationData(VL53L1_ZoneCalibrationData_t  *pZoneCalibrationData)
+VL53L1_Error VL53L1Base::VL53L1_GetZoneCalibrationData(VL53L1_ZoneCalibrationData_t  *pZoneCalibrationData)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
 
@@ -3387,7 +3387,7 @@ VL53L1_Error VL53L1::VL53L1_GetZoneCalibrationData(VL53L1_ZoneCalibrationData_t 
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetOpticalCenter(FixPoint1616_t *pOpticalCenterX, FixPoint1616_t *pOpticalCenterY)
+VL53L1_Error VL53L1Base::VL53L1_GetOpticalCenter(FixPoint1616_t *pOpticalCenterX, FixPoint1616_t *pOpticalCenterY)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_calibration_data_t  CalibrationData;
@@ -3413,7 +3413,7 @@ VL53L1_Error VL53L1::VL53L1_GetOpticalCenter(FixPoint1616_t *pOpticalCenterX, Fi
 
 
 
-VL53L1_Error VL53L1::VL53L1_SetThresholdConfig(VL53L1_DetectionConfig_t *pConfig)
+VL53L1_Error VL53L1Base::VL53L1_SetThresholdConfig(VL53L1_DetectionConfig_t *pConfig)
 {
 #define BADTHRESBOUNDS(T) \
   (((T.CrossMode == VL53L1_THRESHOLD_OUT_OF_WINDOW) || \
@@ -3516,7 +3516,7 @@ VL53L1_Error VL53L1::VL53L1_SetThresholdConfig(VL53L1_DetectionConfig_t *pConfig
 }
 
 
-VL53L1_Error VL53L1::VL53L1_GetThresholdConfig(VL53L1_DetectionConfig_t *pConfig)
+VL53L1_Error VL53L1Base::VL53L1_GetThresholdConfig(VL53L1_DetectionConfig_t *pConfig)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   VL53L1_GPIO_interrupt_config_t Cfg;
@@ -3575,7 +3575,7 @@ VL53L1_Error VL53L1::VL53L1_GetThresholdConfig(VL53L1_DetectionConfig_t *pConfig
 
 
 
-VL53L1_Error VL53L1::VL53L1_PerformOffsetPerVcselCalibration(int32_t CalDistanceMilliMeter)
+VL53L1_Error VL53L1Base::VL53L1_PerformOffsetPerVcselCalibration(int32_t CalDistanceMilliMeter)
 {
   VL53L1_Error Status = VL53L1_ERROR_NONE;
   int32_t sum_ranging_range_A, sum_ranging_range_B;
@@ -3719,7 +3719,7 @@ VL53L1_Error VL53L1::VL53L1_PerformOffsetPerVcselCalibration(int32_t CalDistance
   return Status;
 }
 
-VL53L1_Error VL53L1::VL53L1_WrByte(VL53L1_DEV Dev, uint16_t index, uint8_t data)
+VL53L1_Error VL53L1Base::VL53L1_WrByte(VL53L1_DEV Dev, uint16_t index, uint8_t data)
 {
   int  status;
 
@@ -3727,7 +3727,7 @@ VL53L1_Error VL53L1::VL53L1_WrByte(VL53L1_DEV Dev, uint16_t index, uint8_t data)
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_WrWord(VL53L1_DEV Dev, uint16_t index, uint16_t data)
+VL53L1_Error VL53L1Base::VL53L1_WrWord(VL53L1_DEV Dev, uint16_t index, uint16_t data)
 {
   int  status;
   uint8_t buffer[2];
@@ -3738,7 +3738,7 @@ VL53L1_Error VL53L1::VL53L1_WrWord(VL53L1_DEV Dev, uint16_t index, uint16_t data
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_WrDWord(VL53L1_DEV Dev, uint16_t index, uint32_t data)
+VL53L1_Error VL53L1Base::VL53L1_WrDWord(VL53L1_DEV Dev, uint16_t index, uint32_t data)
 {
   int  status;
   uint8_t buffer[4];
@@ -3751,7 +3751,7 @@ VL53L1_Error VL53L1::VL53L1_WrDWord(VL53L1_DEV Dev, uint16_t index, uint32_t dat
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_RdByte(VL53L1_DEV Dev, uint16_t index, uint8_t *data)
+VL53L1_Error VL53L1Base::VL53L1_RdByte(VL53L1_DEV Dev, uint16_t index, uint8_t *data)
 {
   int  status;
 
@@ -3764,7 +3764,7 @@ VL53L1_Error VL53L1::VL53L1_RdByte(VL53L1_DEV Dev, uint16_t index, uint8_t *data
   return 0;
 }
 
-VL53L1_Error VL53L1::VL53L1_RdWord(VL53L1_DEV Dev, uint16_t index, uint16_t *data)
+VL53L1_Error VL53L1Base::VL53L1_RdWord(VL53L1_DEV Dev, uint16_t index, uint16_t *data)
 {
   int  status;
   uint8_t buffer[2] = {0, 0};
@@ -3776,7 +3776,7 @@ VL53L1_Error VL53L1::VL53L1_RdWord(VL53L1_DEV Dev, uint16_t index, uint16_t *dat
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_RdDWord(VL53L1_DEV Dev, uint16_t index, uint32_t *data)
+VL53L1_Error VL53L1Base::VL53L1_RdDWord(VL53L1_DEV Dev, uint16_t index, uint32_t *data)
 {
   int status;
   uint8_t buffer[4] = {0, 0, 0, 0};
@@ -3788,7 +3788,7 @@ VL53L1_Error VL53L1::VL53L1_RdDWord(VL53L1_DEV Dev, uint16_t index, uint32_t *da
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_UpdateByte(VL53L1_DEV Dev, uint16_t index, uint8_t AndData, uint8_t OrData)
+VL53L1_Error VL53L1Base::VL53L1_UpdateByte(VL53L1_DEV Dev, uint16_t index, uint8_t AndData, uint8_t OrData)
 {
   int  status;
   uint8_t buffer = 0;
@@ -3802,7 +3802,7 @@ VL53L1_Error VL53L1::VL53L1_UpdateByte(VL53L1_DEV Dev, uint16_t index, uint8_t A
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_WriteMulti(VL53L1_DEV Dev, uint16_t index, uint8_t *pdata, uint32_t count)
+VL53L1_Error VL53L1Base::VL53L1_WriteMulti(VL53L1_DEV Dev, uint16_t index, uint8_t *pdata, uint32_t count)
 {
   int  status;
 
@@ -3810,7 +3810,7 @@ VL53L1_Error VL53L1::VL53L1_WriteMulti(VL53L1_DEV Dev, uint16_t index, uint8_t *
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_ReadMulti(VL53L1_DEV Dev, uint16_t index, uint8_t *pdata, uint32_t count)
+VL53L1_Error VL53L1Base::VL53L1_ReadMulti(VL53L1_DEV Dev, uint16_t index, uint8_t *pdata, uint32_t count)
 {
   int status;
 
@@ -3819,7 +3819,7 @@ VL53L1_Error VL53L1::VL53L1_ReadMulti(VL53L1_DEV Dev, uint16_t index, uint8_t *p
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_I2CWrite(uint8_t DeviceAddr, uint16_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToWrite)
+VL53L1_Error VL53L1Base::VL53L1_I2CWrite(uint8_t DeviceAddr, uint16_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToWrite)
 {
 #ifdef DEBUG_MODE
   Serial.print("Beginning transmission to ");
@@ -3840,7 +3840,7 @@ VL53L1_Error VL53L1::VL53L1_I2CWrite(uint8_t DeviceAddr, uint16_t RegisterAddr, 
   return 0;
 }
 
-VL53L1_Error VL53L1::VL53L1_I2CRead(uint8_t DeviceAddr, uint16_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToRead)
+VL53L1_Error VL53L1Base::VL53L1_I2CRead(uint8_t DeviceAddr, uint16_t RegisterAddr, uint8_t *pBuffer, uint16_t NumByteToRead)
 {
   int status = 0;
   //Loop until the port is transmitted correctly
@@ -3879,7 +3879,7 @@ VL53L1_Error VL53L1::VL53L1_I2CRead(uint8_t DeviceAddr, uint16_t RegisterAddr, u
   return 0;
 }
 
-VL53L1_Error VL53L1::VL53L1_GetTickCount(uint32_t *ptick_count_ms)
+VL53L1_Error VL53L1Base::VL53L1_GetTickCount(uint32_t *ptick_count_ms)
 {
   /* Returns current tick count in [ms] */
 
@@ -3891,21 +3891,21 @@ VL53L1_Error VL53L1::VL53L1_GetTickCount(uint32_t *ptick_count_ms)
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_WaitUs(VL53L1_Dev_t *pdev, int32_t wait_us)
+VL53L1_Error VL53L1Base::VL53L1_WaitUs(VL53L1_Dev_t *pdev, int32_t wait_us)
 {
   (void)pdev;
   delay(wait_us / 1000);
   return VL53L1_ERROR_NONE;
 }
 
-VL53L1_Error VL53L1::VL53L1_WaitMs(VL53L1_Dev_t *pdev, int32_t wait_ms)
+VL53L1_Error VL53L1Base::VL53L1_WaitMs(VL53L1_Dev_t *pdev, int32_t wait_ms)
 {
   (void)pdev;
   delay(wait_ms);
   return VL53L1_ERROR_NONE;
 }
 
-VL53L1_Error VL53L1::VL53L1_WaitValueMaskEx(VL53L1_Dev_t *pdev, uint32_t timeout_ms, uint16_t index, uint8_t value, uint8_t mask, uint32_t poll_delay_ms)
+VL53L1_Error VL53L1Base::VL53L1_WaitValueMaskEx(VL53L1_Dev_t *pdev, uint32_t timeout_ms, uint16_t index, uint8_t value, uint8_t mask, uint32_t poll_delay_ms)
 {
   /*
    * Platform implementation of WaitValueMaskEx V2WReg script command

--- a/src/vl53l1_class.h
+++ b/src/vl53l1_class.h
@@ -262,13 +262,13 @@ typedef VL53L1_Dev_t *VL53L1_DEV;
 /* Classes -------------------------------------------------------------------*/
 /** Class representing a VL53L1 sensor component
  */
-class VL53L1 : public RangeSensor {
+class VL53L1Base : public RangeSensor {
   public:
     /** Constructor
      * @param[in] i2c device I2C to be used for communication
      * @param[in] pin shutdown pin to be used as component GPIO0
      */
-    VL53L1(TwoWire *i2c, int pin) : RangeSensor(), dev_i2c(i2c), gpio0(pin)
+    VL53L1Base(TwoWire *i2c, int pin) : RangeSensor(), dev_i2c(i2c), gpio0(pin)
     {
       Dev = &MyDevice;
       memset((void *)Dev, 0x0, sizeof(VL53L1_Dev_t));
@@ -278,7 +278,7 @@ class VL53L1 : public RangeSensor {
 
     /** Destructor
      */
-    virtual ~VL53L1() {}
+    virtual ~VL53L1Base() {}
     /* warning: VL53L1 class inherits from GenericSensor, RangeSensor and LightSensor, that haven`t a destructor.
        The warning should request to introduce a virtual destructor to make sure to delete the object */
 

--- a/src/vl53l1_core.cpp
+++ b/src/vl53l1_core.cpp
@@ -68,7 +68,7 @@
 #include "vl53l1_class.h"
 
 
-void  VL53L1::VL53L1_init_version(
+void  VL53L1Base::VL53L1_init_version(
   VL53L1_DEV        Dev)
 {
 
@@ -82,7 +82,7 @@ void  VL53L1::VL53L1_init_version(
 }
 
 
-void  VL53L1::VL53L1_init_ll_driver_state(
+void  VL53L1Base::VL53L1_init_ll_driver_state(
   VL53L1_DEV         Dev,
   VL53L1_DeviceState device_state)
 {
@@ -106,7 +106,7 @@ void  VL53L1::VL53L1_init_ll_driver_state(
 }
 
 
-VL53L1_Error  VL53L1::VL53L1_update_ll_driver_rd_state(
+VL53L1_Error  VL53L1Base::VL53L1_update_ll_driver_rd_state(
   VL53L1_DEV         Dev)
 {
 
@@ -241,7 +241,7 @@ VL53L1_Error  VL53L1::VL53L1_update_ll_driver_rd_state(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_check_ll_driver_rd_state(
+VL53L1_Error VL53L1Base::VL53L1_check_ll_driver_rd_state(
   VL53L1_DEV         Dev)
 {
 
@@ -356,7 +356,7 @@ ENDFUNC:
 }
 
 
-VL53L1_Error  VL53L1::VL53L1_update_ll_driver_cfg_state(
+VL53L1_Error  VL53L1Base::VL53L1_update_ll_driver_cfg_state(
   VL53L1_DEV         Dev)
 {
 
@@ -507,7 +507,7 @@ VL53L1_Error  VL53L1::VL53L1_update_ll_driver_cfg_state(
 }
 
 
-void VL53L1::VL53L1_copy_rtn_good_spads_to_buffer(
+void VL53L1Base::VL53L1_copy_rtn_good_spads_to_buffer(
   VL53L1_nvm_copy_data_t  *pdata,
   uint8_t                 *pbuffer)
 {
@@ -548,7 +548,7 @@ void VL53L1::VL53L1_copy_rtn_good_spads_to_buffer(
 }
 
 
-void VL53L1::VL53L1_init_system_results(
+void VL53L1Base::VL53L1_init_system_results(
   VL53L1_system_results_t  *pdata)
 {
 
@@ -584,7 +584,7 @@ void VL53L1::VL53L1_init_system_results(
 }
 
 
-void VL53L1::V53L1_init_zone_results_structure(
+void VL53L1Base::V53L1_init_zone_results_structure(
   uint8_t                 active_zones,
   VL53L1_zone_results_t  *pdata)
 {
@@ -606,7 +606,7 @@ void VL53L1::V53L1_init_zone_results_structure(
   }
 }
 
-void VL53L1::V53L1_init_zone_dss_configs(
+void VL53L1Base::V53L1_init_zone_dss_configs(
   VL53L1_DEV              Dev)
 {
 
@@ -626,7 +626,7 @@ void VL53L1::V53L1_init_zone_dss_configs(
 }
 
 
-void VL53L1::VL53L1_init_histogram_config_structure(
+void VL53L1Base::VL53L1_init_histogram_config_structure(
   uint8_t   even_bin0,
   uint8_t   even_bin1,
   uint8_t   even_bin2,
@@ -698,7 +698,7 @@ void VL53L1::VL53L1_init_histogram_config_structure(
 
 }
 
-void VL53L1::VL53L1_init_histogram_multizone_config_structure(
+void VL53L1Base::VL53L1_init_histogram_multizone_config_structure(
   uint8_t   even_bin0,
   uint8_t   even_bin1,
   uint8_t   even_bin2,
@@ -770,7 +770,7 @@ void VL53L1::VL53L1_init_histogram_multizone_config_structure(
 }
 
 
-void VL53L1::VL53L1_init_xtalk_bin_data_struct(
+void VL53L1Base::VL53L1_init_xtalk_bin_data_struct(
   uint32_t                        bin_value,
   uint16_t                        VL53L1_p_024,
   VL53L1_xtalk_histogram_shape_t *pdata)
@@ -806,7 +806,7 @@ void VL53L1::VL53L1_init_xtalk_bin_data_struct(
 }
 
 
-void VL53L1::VL53L1_i2c_encode_uint16_t(
+void VL53L1Base::VL53L1_i2c_encode_uint16_t(
   uint16_t    ip_value,
   uint16_t    count,
   uint8_t    *pbuffer)
@@ -824,7 +824,7 @@ void VL53L1::VL53L1_i2c_encode_uint16_t(
   }
 }
 
-uint16_t VL53L1::VL53L1_i2c_decode_uint16_t(
+uint16_t VL53L1Base::VL53L1_i2c_decode_uint16_t(
   uint16_t    count,
   uint8_t    *pbuffer)
 {
@@ -840,7 +840,7 @@ uint16_t VL53L1::VL53L1_i2c_decode_uint16_t(
 }
 
 
-void VL53L1::VL53L1_i2c_encode_int16_t(
+void VL53L1Base::VL53L1_i2c_encode_int16_t(
   int16_t     ip_value,
   uint16_t    count,
   uint8_t    *pbuffer)
@@ -858,7 +858,7 @@ void VL53L1::VL53L1_i2c_encode_int16_t(
   }
 }
 
-int16_t VL53L1::VL53L1_i2c_decode_int16_t(
+int16_t VL53L1Base::VL53L1_i2c_decode_int16_t(
   uint16_t    count,
   uint8_t    *pbuffer)
 {
@@ -878,7 +878,7 @@ int16_t VL53L1::VL53L1_i2c_decode_int16_t(
   return value;
 }
 
-void VL53L1::VL53L1_i2c_encode_uint32_t(
+void VL53L1Base::VL53L1_i2c_encode_uint32_t(
   uint32_t    ip_value,
   uint16_t    count,
   uint8_t    *pbuffer)
@@ -896,7 +896,7 @@ void VL53L1::VL53L1_i2c_encode_uint32_t(
   }
 }
 
-uint32_t VL53L1::VL53L1_i2c_decode_uint32_t(
+uint32_t VL53L1Base::VL53L1_i2c_decode_uint32_t(
   uint16_t    count,
   uint8_t    *pbuffer)
 {
@@ -912,7 +912,7 @@ uint32_t VL53L1::VL53L1_i2c_decode_uint32_t(
 }
 
 
-uint32_t VL53L1::VL53L1_i2c_decode_with_mask(
+uint32_t VL53L1Base::VL53L1_i2c_decode_with_mask(
   uint16_t    count,
   uint8_t    *pbuffer,
   uint32_t    bit_mask,
@@ -941,7 +941,7 @@ uint32_t VL53L1::VL53L1_i2c_decode_with_mask(
 }
 
 
-void VL53L1::VL53L1_i2c_encode_int32_t(
+void VL53L1Base::VL53L1_i2c_encode_int32_t(
   int32_t     ip_value,
   uint16_t    count,
   uint8_t    *pbuffer)
@@ -959,7 +959,7 @@ void VL53L1::VL53L1_i2c_encode_int32_t(
   }
 }
 
-int32_t VL53L1::VL53L1_i2c_decode_int32_t(
+int32_t VL53L1Base::VL53L1_i2c_decode_int32_t(
   uint16_t    count,
   uint8_t    *pbuffer)
 {
@@ -980,7 +980,7 @@ int32_t VL53L1::VL53L1_i2c_decode_int32_t(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_start_test(
+VL53L1_Error VL53L1Base::VL53L1_start_test(
   VL53L1_DEV    Dev,
   uint8_t       test_mode__ctrl)
 {
@@ -1003,7 +1003,7 @@ VL53L1_Error VL53L1::VL53L1_start_test(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_firmware_enable_register(
+VL53L1_Error VL53L1Base::VL53L1_set_firmware_enable_register(
   VL53L1_DEV    Dev,
   uint8_t       value)
 {
@@ -1022,7 +1022,7 @@ VL53L1_Error VL53L1::VL53L1_set_firmware_enable_register(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_enable_firmware(
+VL53L1_Error VL53L1Base::VL53L1_enable_firmware(
   VL53L1_DEV    Dev)
 {
 
@@ -1039,7 +1039,7 @@ VL53L1_Error VL53L1::VL53L1_enable_firmware(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_disable_firmware(
+VL53L1_Error VL53L1Base::VL53L1_disable_firmware(
   VL53L1_DEV    Dev)
 {
 
@@ -1056,7 +1056,7 @@ VL53L1_Error VL53L1::VL53L1_disable_firmware(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_powerforce_register(
+VL53L1_Error VL53L1Base::VL53L1_set_powerforce_register(
   VL53L1_DEV    Dev,
   uint8_t       value)
 {
@@ -1076,7 +1076,7 @@ VL53L1_Error VL53L1::VL53L1_set_powerforce_register(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_enable_powerforce(
+VL53L1_Error VL53L1Base::VL53L1_enable_powerforce(
   VL53L1_DEV    Dev)
 {
 
@@ -1093,7 +1093,7 @@ VL53L1_Error VL53L1::VL53L1_enable_powerforce(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_disable_powerforce(
+VL53L1_Error VL53L1Base::VL53L1_disable_powerforce(
   VL53L1_DEV    Dev)
 {
 
@@ -1110,7 +1110,7 @@ VL53L1_Error VL53L1::VL53L1_disable_powerforce(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_clear_interrupt(
+VL53L1_Error VL53L1Base::VL53L1_clear_interrupt(
   VL53L1_DEV    Dev)
 {
 
@@ -1133,7 +1133,7 @@ VL53L1_Error VL53L1::VL53L1_clear_interrupt(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_force_shadow_stream_count_to_zero(
+VL53L1_Error VL53L1Base::VL53L1_force_shadow_stream_count_to_zero(
   VL53L1_DEV    Dev)
 {
 
@@ -1159,7 +1159,7 @@ VL53L1_Error VL53L1::VL53L1_force_shadow_stream_count_to_zero(
 }
 
 
-uint32_t VL53L1::VL53L1_calc_macro_period_us(
+uint32_t VL53L1Base::VL53L1_calc_macro_period_us(
   uint16_t  fast_osc_frequency,
   uint8_t   VL53L1_p_009)
 {
@@ -1197,7 +1197,7 @@ uint32_t VL53L1::VL53L1_calc_macro_period_us(
 }
 
 
-uint16_t VL53L1::VL53L1_calc_range_ignore_threshold(
+uint16_t VL53L1Base::VL53L1_calc_range_ignore_threshold(
   uint32_t central_rate,
   int16_t  x_gradient,
   int16_t  y_gradient,
@@ -1262,7 +1262,7 @@ uint16_t VL53L1::VL53L1_calc_range_ignore_threshold(
 }
 
 
-uint32_t VL53L1::VL53L1_calc_timeout_mclks(
+uint32_t VL53L1Base::VL53L1_calc_timeout_mclks(
   uint32_t timeout_us,
   uint32_t macro_period_us)
 {
@@ -1282,7 +1282,7 @@ uint32_t VL53L1::VL53L1_calc_timeout_mclks(
 }
 
 
-uint16_t VL53L1::VL53L1_calc_encoded_timeout(
+uint16_t VL53L1Base::VL53L1_calc_encoded_timeout(
   uint32_t timeout_us,
   uint32_t macro_period_us)
 {
@@ -1307,7 +1307,7 @@ uint16_t VL53L1::VL53L1_calc_encoded_timeout(
 }
 
 
-uint32_t VL53L1::VL53L1_calc_timeout_us(
+uint32_t VL53L1Base::VL53L1_calc_timeout_us(
   uint32_t timeout_mclks,
   uint32_t macro_period_us)
 {
@@ -1331,7 +1331,7 @@ uint32_t VL53L1::VL53L1_calc_timeout_us(
   return timeout_us;
 }
 
-uint32_t VL53L1::VL53L1_calc_crosstalk_plane_offset_with_margin(
+uint32_t VL53L1Base::VL53L1_calc_crosstalk_plane_offset_with_margin(
   uint32_t     plane_offset_kcps,
   int16_t      margin_offset_kcps)
 {
@@ -1358,7 +1358,7 @@ uint32_t VL53L1::VL53L1_calc_crosstalk_plane_offset_with_margin(
 
 }
 
-uint32_t VL53L1::VL53L1_calc_decoded_timeout_us(
+uint32_t VL53L1Base::VL53L1_calc_decoded_timeout_us(
   uint16_t timeout_encoded,
   uint32_t macro_period_us)
 {
@@ -1381,7 +1381,7 @@ uint32_t VL53L1::VL53L1_calc_decoded_timeout_us(
 }
 
 
-uint16_t VL53L1::VL53L1_encode_timeout(uint32_t timeout_mclks)
+uint16_t VL53L1Base::VL53L1_encode_timeout(uint32_t timeout_mclks)
 {
 
 
@@ -1405,7 +1405,7 @@ uint16_t VL53L1::VL53L1_encode_timeout(uint32_t timeout_mclks)
 }
 
 
-uint32_t VL53L1::VL53L1_decode_timeout(uint16_t encoded_timeout)
+uint32_t VL53L1Base::VL53L1_decode_timeout(uint16_t encoded_timeout)
 {
 
 
@@ -1418,7 +1418,7 @@ uint32_t VL53L1::VL53L1_decode_timeout(uint16_t encoded_timeout)
 }
 
 
-VL53L1_Error VL53L1::VL53L1_calc_timeout_register_values(
+VL53L1_Error VL53L1Base::VL53L1_calc_timeout_register_values(
   uint32_t                 phasecal_config_timeout_us,
   uint32_t                 mm_config_timeout_us,
   uint32_t                 range_config_timeout_us,
@@ -1516,7 +1516,7 @@ VL53L1_Error VL53L1::VL53L1_calc_timeout_register_values(
 }
 
 
-uint8_t VL53L1::VL53L1_encode_vcsel_period(uint8_t VL53L1_p_031)
+uint8_t VL53L1Base::VL53L1_encode_vcsel_period(uint8_t VL53L1_p_031)
 {
 
 
@@ -1528,7 +1528,7 @@ uint8_t VL53L1::VL53L1_encode_vcsel_period(uint8_t VL53L1_p_031)
 }
 
 
-uint32_t VL53L1::VL53L1_decode_unsigned_integer(
+uint32_t VL53L1Base::VL53L1_decode_unsigned_integer(
   uint8_t  *pbuffer,
   uint8_t   no_of_bytes)
 {
@@ -1545,7 +1545,7 @@ uint32_t VL53L1::VL53L1_decode_unsigned_integer(
 }
 
 
-void VL53L1::VL53L1_encode_unsigned_integer(
+void VL53L1Base::VL53L1_encode_unsigned_integer(
   uint32_t  ip_value,
   uint8_t   no_of_bytes,
   uint8_t  *pbuffer)
@@ -1563,7 +1563,7 @@ void VL53L1::VL53L1_encode_unsigned_integer(
 }
 
 
-VL53L1_Error  VL53L1::VL53L1_hist_copy_and_scale_ambient_info(
+VL53L1_Error  VL53L1Base::VL53L1_hist_copy_and_scale_ambient_info(
   VL53L1_zone_hist_info_t       *pidata,
   VL53L1_histogram_bin_data_t   *podata)
 {
@@ -1622,7 +1622,7 @@ VL53L1_Error  VL53L1::VL53L1_hist_copy_and_scale_ambient_info(
 }
 
 
-void  VL53L1::VL53L1_hist_get_bin_sequence_config(
+void  VL53L1Base::VL53L1_hist_get_bin_sequence_config(
   VL53L1_DEV                     Dev,
   VL53L1_histogram_bin_data_t   *pdata)
 {
@@ -1777,7 +1777,7 @@ void  VL53L1::VL53L1_hist_get_bin_sequence_config(
 }
 
 
-VL53L1_Error  VL53L1::VL53L1_hist_phase_consistency_check(
+VL53L1_Error  VL53L1Base::VL53L1_hist_phase_consistency_check(
   VL53L1_DEV                   Dev,
   VL53L1_zone_hist_info_t     *phist_prev,
   VL53L1_zone_objects_t       *prange_prev,
@@ -1918,7 +1918,7 @@ VL53L1_Error  VL53L1::VL53L1_hist_phase_consistency_check(
 
 
 
-VL53L1_Error  VL53L1::VL53L1_hist_events_consistency_check(
+VL53L1_Error  VL53L1Base::VL53L1_hist_events_consistency_check(
   uint8_t                      event_sigma,
   uint16_t                     min_effective_spad_count,
   VL53L1_zone_hist_info_t     *phist_prev,
@@ -2045,7 +2045,7 @@ VL53L1_Error  VL53L1::VL53L1_hist_events_consistency_check(
 
 
 
-VL53L1_Error  VL53L1::VL53L1_hist_merged_pulse_check(
+VL53L1_Error  VL53L1Base::VL53L1_hist_merged_pulse_check(
   int16_t                      min_max_tolerance_mm,
   VL53L1_range_data_t         *pdata,
   VL53L1_DeviceError          *prange_status)
@@ -2075,7 +2075,7 @@ VL53L1_Error  VL53L1::VL53L1_hist_merged_pulse_check(
 
 
 
-VL53L1_Error  VL53L1::VL53L1_hist_xmonitor_consistency_check(
+VL53L1_Error  VL53L1Base::VL53L1_hist_xmonitor_consistency_check(
   VL53L1_DEV                   Dev,
   VL53L1_zone_hist_info_t     *phist_prev,
   VL53L1_zone_objects_t       *prange_prev,
@@ -2132,7 +2132,7 @@ VL53L1_Error  VL53L1::VL53L1_hist_xmonitor_consistency_check(
 
 
 
-VL53L1_Error  VL53L1::VL53L1_hist_wrap_dmax(
+VL53L1_Error  VL53L1Base::VL53L1_hist_wrap_dmax(
   VL53L1_hist_post_process_config_t  *phistpostprocess,
   VL53L1_histogram_bin_data_t        *pcurrent,
   int16_t                            *pwrap_dmax_mm)
@@ -2178,7 +2178,7 @@ VL53L1_Error  VL53L1::VL53L1_hist_wrap_dmax(
 }
 
 
-void VL53L1::VL53L1_hist_combine_mm1_mm2_offsets(
+void VL53L1Base::VL53L1_hist_combine_mm1_mm2_offsets(
   int16_t                               mm1_offset_mm,
   int16_t                               mm2_offset_mm,
   uint8_t                               encoded_mm_roi_centre,
@@ -2264,7 +2264,7 @@ FAIL:
 }
 
 
-VL53L1_Error VL53L1::VL53L1_hist_xtalk_extract_calc_window(
+VL53L1_Error VL53L1Base::VL53L1_hist_xtalk_extract_calc_window(
   int16_t                             target_distance_mm,
   uint16_t                            target_width_oversize,
   VL53L1_histogram_bin_data_t        *phist_bins,
@@ -2390,7 +2390,7 @@ VL53L1_Error VL53L1::VL53L1_hist_xtalk_extract_calc_window(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_hist_xtalk_extract_calc_event_sums(
+VL53L1_Error VL53L1Base::VL53L1_hist_xtalk_extract_calc_event_sums(
   VL53L1_histogram_bin_data_t        *phist_bins,
   VL53L1_hist_xtalk_extract_data_t   *pxtalk_data)
 {
@@ -2445,7 +2445,7 @@ VL53L1_Error VL53L1::VL53L1_hist_xtalk_extract_calc_event_sums(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_hist_xtalk_extract_calc_rate_per_spad(
+VL53L1_Error VL53L1Base::VL53L1_hist_xtalk_extract_calc_rate_per_spad(
   VL53L1_hist_xtalk_extract_data_t   *pxtalk_data)
 {
 
@@ -2495,7 +2495,7 @@ VL53L1_Error VL53L1::VL53L1_hist_xtalk_extract_calc_rate_per_spad(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_hist_xtalk_extract_calc_shape(
+VL53L1_Error VL53L1Base::VL53L1_hist_xtalk_extract_calc_shape(
   VL53L1_hist_xtalk_extract_data_t  *pxtalk_data,
   VL53L1_xtalk_histogram_shape_t    *pxtalk_shape)
 {
@@ -2590,7 +2590,7 @@ VL53L1_Error VL53L1::VL53L1_hist_xtalk_extract_calc_shape(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_hist_xtalk_shape_model(
+VL53L1_Error VL53L1Base::VL53L1_hist_xtalk_shape_model(
   uint16_t                         events_per_bin,
   uint16_t                         pulse_centre,
   uint16_t                         pulse_width,
@@ -2680,7 +2680,7 @@ VL53L1_Error VL53L1::VL53L1_hist_xtalk_shape_model(
 }
 
 
-uint16_t VL53L1::VL53L1_hist_xtalk_shape_model_interp(
+uint16_t VL53L1Base::VL53L1_hist_xtalk_shape_model_interp(
   uint16_t      events_per_bin,
   uint32_t      phase_delta)
 {
@@ -2706,7 +2706,7 @@ uint16_t VL53L1::VL53L1_hist_xtalk_shape_model_interp(
 }
 
 
-void VL53L1::VL53L1_spad_number_to_byte_bit_index(
+void VL53L1Base::VL53L1_spad_number_to_byte_bit_index(
   uint8_t  spad_number,
   uint8_t *pbyte_index,
   uint8_t *pbit_index,
@@ -2722,7 +2722,7 @@ void VL53L1::VL53L1_spad_number_to_byte_bit_index(
 }
 
 
-void VL53L1::VL53L1_encode_row_col(
+void VL53L1Base::VL53L1_encode_row_col(
   uint8_t  row,
   uint8_t  col,
   uint8_t *pspad_number)
@@ -2738,7 +2738,7 @@ void VL53L1::VL53L1_encode_row_col(
 }
 
 
-void VL53L1::VL53L1_decode_zone_size(
+void VL53L1Base::VL53L1_decode_zone_size(
   uint8_t  encoded_xy_size,
   uint8_t  *pwidth,
   uint8_t  *pheight)
@@ -2752,7 +2752,7 @@ void VL53L1::VL53L1_decode_zone_size(
 }
 
 
-void VL53L1::VL53L1_encode_zone_size(
+void VL53L1Base::VL53L1_encode_zone_size(
   uint8_t  width,
   uint8_t  height,
   uint8_t *pencoded_xy_size)
@@ -2764,7 +2764,7 @@ void VL53L1::VL53L1_encode_zone_size(
 }
 
 
-void VL53L1::VL53L1_decode_zone_limits(
+void VL53L1Base::VL53L1_decode_zone_limits(
   uint8_t   encoded_xy_centre,
   uint8_t   encoded_xy_size,
   int16_t  *px_ll,
@@ -2816,7 +2816,7 @@ void VL53L1::VL53L1_decode_zone_limits(
 }
 
 
-uint8_t VL53L1::VL53L1_is_aperture_location(
+uint8_t VL53L1Base::VL53L1_is_aperture_location(
   uint8_t row,
   uint8_t col)
 {
@@ -2838,7 +2838,7 @@ uint8_t VL53L1::VL53L1_is_aperture_location(
 }
 
 
-void VL53L1::VL53L1_calc_max_effective_spads(
+void VL53L1Base::VL53L1_calc_max_effective_spads(
   uint8_t     encoded_zone_centre,
   uint8_t     encoded_zone_size,
   uint8_t    *pgood_spads,
@@ -2917,7 +2917,7 @@ void VL53L1::VL53L1_calc_max_effective_spads(
 }
 
 
-void VL53L1::VL53L1_calc_mm_effective_spads(
+void VL53L1Base::VL53L1_calc_mm_effective_spads(
   uint8_t     encoded_mm_roi_centre,
   uint8_t     encoded_mm_roi_size,
   uint8_t     encoded_zone_centre,
@@ -3022,7 +3022,7 @@ void VL53L1::VL53L1_calc_mm_effective_spads(
 }
 
 
-void VL53L1::VL53L1_hist_copy_results_to_sys_and_core(
+void VL53L1Base::VL53L1_hist_copy_results_to_sys_and_core(
   VL53L1_histogram_bin_data_t      *pbins,
   VL53L1_range_results_t           *phist,
   VL53L1_system_results_t          *psys,
@@ -3113,7 +3113,7 @@ void VL53L1::VL53L1_hist_copy_results_to_sys_and_core(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_sum_histogram_data(
+VL53L1_Error VL53L1Base::VL53L1_sum_histogram_data(
   VL53L1_histogram_bin_data_t *phist_input,
   VL53L1_histogram_bin_data_t *phist_output)
 {
@@ -3159,7 +3159,7 @@ VL53L1_Error VL53L1::VL53L1_sum_histogram_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_avg_histogram_data(
+VL53L1_Error VL53L1Base::VL53L1_avg_histogram_data(
   uint8_t no_of_samples,
   VL53L1_histogram_bin_data_t *phist_sum,
   VL53L1_histogram_bin_data_t *phist_avg)
@@ -3207,7 +3207,7 @@ VL53L1_Error VL53L1::VL53L1_avg_histogram_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_save_cfg_data(
+VL53L1_Error VL53L1Base::VL53L1_save_cfg_data(
   VL53L1_DEV  Dev)
 {
 
@@ -3245,7 +3245,7 @@ VL53L1_Error VL53L1::VL53L1_save_cfg_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_dynamic_zone_update(
+VL53L1_Error VL53L1Base::VL53L1_dynamic_zone_update(
   VL53L1_DEV  Dev,
   VL53L1_range_results_t *presults)
 {
@@ -3312,7 +3312,7 @@ VL53L1_Error VL53L1::VL53L1_dynamic_zone_update(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_multizone_hist_bins_update(
+VL53L1_Error VL53L1Base::VL53L1_multizone_hist_bins_update(
   VL53L1_DEV  Dev)
 {
 
@@ -3406,7 +3406,7 @@ VL53L1_Error VL53L1::VL53L1_multizone_hist_bins_update(
 
 
 
-VL53L1_Error VL53L1::VL53L1_update_internal_stream_counters(
+VL53L1_Error VL53L1Base::VL53L1_update_internal_stream_counters(
   VL53L1_DEV  Dev,
   uint8_t     external_stream_count,
   uint8_t    *pinternal_stream_count,
@@ -3453,7 +3453,7 @@ VL53L1_Error VL53L1::VL53L1_update_internal_stream_counters(
 
 
 
-VL53L1_Error VL53L1::VL53L1_set_histogram_multizone_initial_bin_config(
+VL53L1_Error VL53L1Base::VL53L1_set_histogram_multizone_initial_bin_config(
   VL53L1_zone_config_t    *pzone_cfg,
   VL53L1_histogram_config_t *phist_cfg,
   VL53L1_histogram_config_t *pmulti_hist)
@@ -3515,7 +3515,7 @@ VL53L1_Error VL53L1::VL53L1_set_histogram_multizone_initial_bin_config(
 
 
 
-uint8_t VL53L1::VL53L1_encode_GPIO_interrupt_config(
+uint8_t VL53L1Base::VL53L1_encode_GPIO_interrupt_config(
   VL53L1_GPIO_interrupt_config_t  *pintconf)
 {
   uint8_t system__interrupt_config;
@@ -3531,7 +3531,7 @@ uint8_t VL53L1::VL53L1_encode_GPIO_interrupt_config(
 
 
 
-VL53L1_GPIO_interrupt_config_t VL53L1::VL53L1_decode_GPIO_interrupt_config(
+VL53L1_GPIO_interrupt_config_t VL53L1Base::VL53L1_decode_GPIO_interrupt_config(
   uint8_t   system__interrupt_config)
 {
   VL53L1_GPIO_interrupt_config_t  intconf;
@@ -3553,7 +3553,7 @@ VL53L1_GPIO_interrupt_config_t VL53L1::VL53L1_decode_GPIO_interrupt_config(
 
 
 
-VL53L1_Error VL53L1::VL53L1_set_GPIO_distance_threshold(
+VL53L1_Error VL53L1Base::VL53L1_set_GPIO_distance_threshold(
   VL53L1_DEV                      Dev,
   uint16_t      threshold_high,
   uint16_t      threshold_low)
@@ -3573,7 +3573,7 @@ VL53L1_Error VL53L1::VL53L1_set_GPIO_distance_threshold(
 
 
 
-VL53L1_Error VL53L1::VL53L1_set_GPIO_rate_threshold(
+VL53L1_Error VL53L1Base::VL53L1_set_GPIO_rate_threshold(
   VL53L1_DEV                      Dev,
   uint16_t      threshold_high,
   uint16_t      threshold_low)
@@ -3593,7 +3593,7 @@ VL53L1_Error VL53L1::VL53L1_set_GPIO_rate_threshold(
 
 
 
-VL53L1_Error VL53L1::VL53L1_set_GPIO_thresholds_from_struct(
+VL53L1_Error VL53L1Base::VL53L1_set_GPIO_thresholds_from_struct(
   VL53L1_DEV                      Dev,
   VL53L1_GPIO_interrupt_config_t *pintconf)
 {
@@ -3619,7 +3619,7 @@ VL53L1_Error VL53L1::VL53L1_set_GPIO_thresholds_from_struct(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_ref_spad_char_config(
+VL53L1_Error VL53L1Base::VL53L1_set_ref_spad_char_config(
   VL53L1_DEV    Dev,
   uint8_t       vcsel_period_a,
   uint32_t      phasecal_timeout_us,
@@ -3721,7 +3721,7 @@ VL53L1_Error VL53L1::VL53L1_set_ref_spad_char_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_ssc_config(
+VL53L1_Error VL53L1Base::VL53L1_set_ssc_config(
   VL53L1_DEV            Dev,
   VL53L1_ssc_config_t  *pssc_cfg,
   uint16_t              fast_osc_frequency)
@@ -3807,7 +3807,7 @@ VL53L1_Error VL53L1::VL53L1_set_ssc_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_spad_rate_data(
+VL53L1_Error VL53L1Base::VL53L1_get_spad_rate_data(
   VL53L1_DEV                Dev,
   VL53L1_spad_rate_data_t  *pspad_rates)
 {
@@ -3865,7 +3865,7 @@ VL53L1_Error VL53L1::VL53L1_get_spad_rate_data(
 
 
 
-VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_calc_required_samples(
+VL53L1_Error VL53L1Base::VL53L1_dynamic_xtalk_correction_calc_required_samples(
   VL53L1_DEV                          Dev
 )
 {
@@ -3921,7 +3921,7 @@ VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_calc_required_samples(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_calc_new_xtalk(
+VL53L1_Error VL53L1Base::VL53L1_dynamic_xtalk_correction_calc_new_xtalk(
   VL53L1_DEV        Dev,
   uint32_t        xtalk_offset_out,
   VL53L1_smudge_corrector_config_t  *pconfig,
@@ -4135,7 +4135,7 @@ VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_calc_new_xtalk(
 #define CONT_CONTINUE 0
 #define CONT_NEXT_LOOP  1
 #define CONT_RESET  2
-VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_corrector(
+VL53L1_Error VL53L1Base::VL53L1_dynamic_xtalk_correction_corrector(
   VL53L1_DEV                          Dev
 )
 {
@@ -4463,7 +4463,7 @@ VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_corrector(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_data_init(
+VL53L1_Error VL53L1Base::VL53L1_dynamic_xtalk_correction_data_init(
   VL53L1_DEV                          Dev
 )
 {
@@ -4536,7 +4536,7 @@ VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_data_init(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_output_init(
+VL53L1_Error VL53L1Base::VL53L1_dynamic_xtalk_correction_output_init(
   VL53L1_LLDriverResults_t *pres
 )
 {
@@ -4571,7 +4571,7 @@ VL53L1_Error VL53L1::VL53L1_dynamic_xtalk_correction_output_init(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_xtalk_cal_data_init(
+VL53L1_Error VL53L1Base::VL53L1_xtalk_cal_data_init(
   VL53L1_DEV                          Dev
 )
 {
@@ -4603,7 +4603,7 @@ VL53L1_Error VL53L1::VL53L1_xtalk_cal_data_init(
 
 
 
-VL53L1_Error VL53L1::VL53L1_low_power_auto_data_init(
+VL53L1_Error VL53L1Base::VL53L1_low_power_auto_data_init(
   VL53L1_DEV                          Dev
 )
 {
@@ -4633,7 +4633,7 @@ VL53L1_Error VL53L1::VL53L1_low_power_auto_data_init(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_low_power_auto_data_stop_range(
+VL53L1_Error VL53L1Base::VL53L1_low_power_auto_data_stop_range(
   VL53L1_DEV                          Dev
 )
 {
@@ -4671,7 +4671,7 @@ VL53L1_Error VL53L1::VL53L1_low_power_auto_data_stop_range(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_config_low_power_auto_mode(
+VL53L1_Error VL53L1Base::VL53L1_config_low_power_auto_mode(
   VL53L1_general_config_t   *pgeneral,
   VL53L1_dynamic_config_t   *pdynamic,
   VL53L1_low_power_auto_data_t *plpadata
@@ -4711,7 +4711,7 @@ VL53L1_Error VL53L1::VL53L1_config_low_power_auto_mode(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_low_power_auto_setup_manual_calibration(
+VL53L1_Error VL53L1Base::VL53L1_low_power_auto_setup_manual_calibration(
   VL53L1_DEV        Dev)
 {
 
@@ -4748,7 +4748,7 @@ VL53L1_Error VL53L1::VL53L1_low_power_auto_setup_manual_calibration(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_low_power_auto_update_DSS(
+VL53L1_Error VL53L1Base::VL53L1_low_power_auto_update_DSS(
   VL53L1_DEV        Dev)
 {
 
@@ -4847,7 +4847,7 @@ VL53L1_Error VL53L1::VL53L1_low_power_auto_update_DSS(
 
 
 
-VL53L1_Error VL53L1::VL53L1_compute_histo_merge_nb(
+VL53L1_Error VL53L1Base::VL53L1_compute_histo_merge_nb(
   VL53L1_DEV        Dev,  uint8_t *histo_merge_nb)
 {
   VL53L1_LLDriverData_t *pdev = VL53L1DevStructGetLLDriverHandle(Dev);

--- a/src/vl53l1_core_support.cpp
+++ b/src/vl53l1_core_support.cpp
@@ -68,7 +68,7 @@
 #include "vl53l1_class.h"
 
 
-uint32_t VL53L1::VL53L1_calc_pll_period_us(
+uint32_t VL53L1Base::VL53L1_calc_pll_period_us(
   uint16_t  fast_osc_frequency)
 {
 
@@ -89,7 +89,7 @@ uint32_t VL53L1::VL53L1_calc_pll_period_us(
 }
 
 
-uint32_t  VL53L1::VL53L1_duration_maths(
+uint32_t  VL53L1Base::VL53L1_duration_maths(
   uint32_t  pll_period_us,
   uint32_t  vcsel_parm_pclks,
   uint32_t  window_vclks,
@@ -132,7 +132,7 @@ uint32_t  VL53L1::VL53L1_duration_maths(
 }
 
 
-uint32_t VL53L1::VL53L1_events_per_spad_maths(
+uint32_t VL53L1Base::VL53L1_events_per_spad_maths(
   int32_t   VL53L1_p_013,
   uint16_t  num_spads,
   uint32_t  duration)
@@ -172,7 +172,7 @@ uint32_t VL53L1::VL53L1_events_per_spad_maths(
 }
 
 
-uint32_t VL53L1::VL53L1_isqrt(uint32_t num)
+uint32_t VL53L1Base::VL53L1_isqrt(uint32_t num)
 {
 
 
@@ -199,7 +199,7 @@ uint32_t VL53L1::VL53L1_isqrt(uint32_t num)
 }
 
 
-void  VL53L1::VL53L1_hist_calc_zero_distance_phase(
+void  VL53L1Base::VL53L1_hist_calc_zero_distance_phase(
   VL53L1_histogram_bin_data_t   *pdata)
 {
 
@@ -225,7 +225,7 @@ void  VL53L1::VL53L1_hist_calc_zero_distance_phase(
 }
 
 
-void  VL53L1::VL53L1_hist_estimate_ambient_from_thresholded_bins(
+void  VL53L1Base::VL53L1_hist_estimate_ambient_from_thresholded_bins(
   int32_t                        ambient_threshold_sigma,
   VL53L1_histogram_bin_data_t   *pdata)
 {
@@ -275,7 +275,7 @@ void  VL53L1::VL53L1_hist_estimate_ambient_from_thresholded_bins(
 }
 
 
-void  VL53L1::VL53L1_hist_remove_ambient_bins(
+void  VL53L1Base::VL53L1_hist_remove_ambient_bins(
   VL53L1_histogram_bin_data_t   *pdata)
 {
 
@@ -324,7 +324,7 @@ void  VL53L1::VL53L1_hist_remove_ambient_bins(
 }
 
 
-uint32_t VL53L1::VL53L1_calc_pll_period_mm(
+uint32_t VL53L1Base::VL53L1_calc_pll_period_mm(
   uint16_t fast_osc_frequency)
 {
 
@@ -354,7 +354,7 @@ uint32_t VL53L1::VL53L1_calc_pll_period_mm(
 }
 
 
-uint16_t VL53L1::VL53L1_rate_maths(
+uint16_t VL53L1Base::VL53L1_rate_maths(
   int32_t   VL53L1_p_008,
   uint32_t  time_us)
 {
@@ -403,7 +403,7 @@ uint16_t VL53L1::VL53L1_rate_maths(
 }
 
 
-uint16_t VL53L1::VL53L1_rate_per_spad_maths(
+uint16_t VL53L1Base::VL53L1_rate_per_spad_maths(
   uint32_t  frac_bits,
   uint32_t  peak_count_rate,
   uint16_t  num_spads,
@@ -440,7 +440,7 @@ uint16_t VL53L1::VL53L1_rate_per_spad_maths(
 }
 
 
-int32_t VL53L1::VL53L1_range_maths(
+int32_t VL53L1Base::VL53L1_range_maths(
   uint16_t  fast_osc_frequency,
   uint16_t  VL53L1_p_017,
   uint16_t  zero_distance_phase,
@@ -504,7 +504,7 @@ int32_t VL53L1::VL53L1_range_maths(
 }
 
 
-uint8_t VL53L1::VL53L1_decode_vcsel_period(uint8_t vcsel_period_reg)
+uint8_t VL53L1Base::VL53L1_decode_vcsel_period(uint8_t vcsel_period_reg)
 {
 
 
@@ -516,7 +516,7 @@ uint8_t VL53L1::VL53L1_decode_vcsel_period(uint8_t vcsel_period_reg)
 }
 
 
-void VL53L1::VL53L1_copy_xtalk_bin_data_to_histogram_data_struct(
+void VL53L1Base::VL53L1_copy_xtalk_bin_data_to_histogram_data_struct(
   VL53L1_xtalk_histogram_shape_t *pxtalk,
   VL53L1_histogram_bin_data_t    *phist)
 {
@@ -545,7 +545,7 @@ void VL53L1::VL53L1_copy_xtalk_bin_data_to_histogram_data_struct(
 }
 
 
-void VL53L1::VL53L1_init_histogram_bin_data_struct(
+void VL53L1Base::VL53L1_init_histogram_bin_data_struct(
   int32_t                      bin_value,
   uint16_t                     VL53L1_p_024,
   VL53L1_histogram_bin_data_t *pdata)
@@ -609,7 +609,7 @@ void VL53L1::VL53L1_init_histogram_bin_data_struct(
 }
 
 
-void VL53L1::VL53L1_decode_row_col(
+void VL53L1Base::VL53L1_decode_row_col(
   uint8_t  spad_number,
   uint8_t  *prow,
   uint8_t  *pcol)
@@ -627,7 +627,7 @@ void VL53L1::VL53L1_decode_row_col(
 }
 
 
-void  VL53L1::VL53L1_hist_find_min_max_bin_values(
+void  VL53L1Base::VL53L1_hist_find_min_max_bin_values(
   VL53L1_histogram_bin_data_t   *pdata)
 {
 
@@ -653,7 +653,7 @@ void  VL53L1::VL53L1_hist_find_min_max_bin_values(
 }
 
 
-void  VL53L1::VL53L1_hist_estimate_ambient_from_ambient_bins(
+void  VL53L1Base::VL53L1_hist_estimate_ambient_from_ambient_bins(
   VL53L1_histogram_bin_data_t   *pdata)
 {
 

--- a/src/vl53l1_dmax.cpp
+++ b/src/vl53l1_dmax.cpp
@@ -19,7 +19,7 @@
 #include "vl53l1_class.h"
 
 
-VL53L1_Error VL53L1::VL53L1_f_001(
+VL53L1_Error VL53L1Base::VL53L1_f_001(
   uint16_t                              target_reflectance,
   VL53L1_dmax_calibration_data_t       *pcal,
   VL53L1_hist_gen3_dmax_config_t       *pcfg,
@@ -230,7 +230,7 @@ VL53L1_Error VL53L1::VL53L1_f_001(
 }
 
 
-uint32_t VL53L1::VL53L1_f_002(
+uint32_t VL53L1Base::VL53L1_f_002(
   uint32_t     events_threshold,
   uint32_t     ref_signal_events,
   uint32_t   ref_distance_mm,

--- a/src/vl53l1_error_strings.cpp
+++ b/src/vl53l1_error_strings.cpp
@@ -67,7 +67,7 @@
 
 #include "vl53l1_class.h"
 
-VL53L1_Error VL53L1::VL53L1_get_pal_error_string(
+VL53L1_Error VL53L1Base::VL53L1_get_pal_error_string(
   VL53L1_Error   PalErrorCode,
   char          *pPalErrorString)
 {

--- a/src/vl53l1_hist_algos_gen3.cpp
+++ b/src/vl53l1_hist_algos_gen3.cpp
@@ -19,7 +19,7 @@
 #include "vl53l1_class.h"
 
 
-void VL53L1::VL53L1_f_016(
+void VL53L1Base::VL53L1_f_016(
   VL53L1_hist_gen3_algo_private_data_t   *palgo)
 {
 
@@ -71,7 +71,7 @@ void VL53L1::VL53L1_f_016(
 
 
 
-VL53L1_Error VL53L1::VL53L1_f_018(
+VL53L1_Error VL53L1Base::VL53L1_f_018(
   uint16_t                          ambient_threshold_events_scaler,
   int32_t                           ambient_threshold_sigma,
   int32_t                           min_ambient_threshold_events,
@@ -175,7 +175,7 @@ VL53L1_Error VL53L1::VL53L1_f_018(
 
 
 
-VL53L1_Error VL53L1::VL53L1_f_019(
+VL53L1_Error VL53L1Base::VL53L1_f_019(
   VL53L1_hist_gen3_algo_private_data_t  *palgo)
 {
 
@@ -213,7 +213,7 @@ VL53L1_Error VL53L1::VL53L1_f_019(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_020(
+VL53L1_Error VL53L1Base::VL53L1_f_020(
   VL53L1_hist_gen3_algo_private_data_t  *palgo)
 {
 
@@ -266,7 +266,7 @@ VL53L1_Error VL53L1::VL53L1_f_020(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_021(
+VL53L1_Error VL53L1Base::VL53L1_f_021(
   VL53L1_hist_gen3_algo_private_data_t  *palgo)
 {
 
@@ -359,7 +359,7 @@ VL53L1_Error VL53L1::VL53L1_f_021(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_028(
+VL53L1_Error VL53L1Base::VL53L1_f_028(
   VL53L1_HistTargetOrder                target_order,
   VL53L1_hist_gen3_algo_private_data_t  *palgo)
 {
@@ -439,7 +439,7 @@ ENDFUNC:
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_022(
+VL53L1_Error VL53L1Base::VL53L1_f_022(
   uint8_t                                pulse_no,
   VL53L1_histogram_bin_data_t           *pbins,
   VL53L1_hist_gen3_algo_private_data_t  *palgo)
@@ -477,7 +477,7 @@ VL53L1_Error VL53L1::VL53L1_f_022(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_027(
+VL53L1_Error VL53L1Base::VL53L1_f_027(
   uint8_t                                pulse_no,
   uint8_t                                clip_events,
   VL53L1_histogram_bin_data_t           *pbins,
@@ -558,7 +558,7 @@ VL53L1_Error VL53L1::VL53L1_f_027(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_030(
+VL53L1_Error VL53L1Base::VL53L1_f_030(
   int16_t                            VL53L1_p_022,
   int16_t                            VL53L1_p_026,
   uint8_t                            VL53L1_p_031,
@@ -623,7 +623,7 @@ VL53L1_Error VL53L1::VL53L1_f_030(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_023(
+VL53L1_Error VL53L1Base::VL53L1_f_023(
   uint8_t                                pulse_no,
   VL53L1_histogram_bin_data_t           *pbins,
   VL53L1_hist_gen3_algo_private_data_t  *palgo,
@@ -667,7 +667,7 @@ VL53L1_Error VL53L1::VL53L1_f_023(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_026(
+VL53L1_Error VL53L1Base::VL53L1_f_026(
   uint8_t                       bin,
   uint8_t                       sigma_estimator__sigma_ref_mm,
   uint8_t                       VL53L1_p_031,
@@ -759,7 +759,7 @@ VL53L1_Error VL53L1::VL53L1_f_026(
 }
 
 
-void VL53L1::VL53L1_f_029(
+void VL53L1Base::VL53L1_f_029(
   uint8_t                      range_id,
   uint8_t                      valid_phase_low,
   uint8_t                      valid_phase_high,

--- a/src/vl53l1_hist_algos_gen4.cpp
+++ b/src/vl53l1_hist_algos_gen4.cpp
@@ -17,7 +17,7 @@
 #include "vl53l1_class.h"
 
 
-void VL53L1::VL53L1_f_032(
+void VL53L1Base::VL53L1_f_032(
   VL53L1_hist_gen4_algo_filtered_data_t   *palgo)
 {
 
@@ -39,7 +39,7 @@ void VL53L1::VL53L1_f_032(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_033(
+VL53L1_Error VL53L1Base::VL53L1_f_033(
   VL53L1_dmax_calibration_data_t         *pdmax_cal,
   VL53L1_hist_gen3_dmax_config_t         *pdmax_cfg,
   VL53L1_hist_post_process_config_t      *ppost_cfg,
@@ -329,7 +329,7 @@ VL53L1_Error VL53L1::VL53L1_f_033(
 
 
 
-VL53L1_Error VL53L1::VL53L1_f_034(
+VL53L1_Error VL53L1Base::VL53L1_f_034(
   uint8_t                                pulse_no,
   VL53L1_histogram_bin_data_t           *ppulse,
   VL53L1_hist_gen3_algo_private_data_t  *palgo3,
@@ -392,7 +392,7 @@ VL53L1_Error VL53L1::VL53L1_f_034(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_035(
+VL53L1_Error VL53L1Base::VL53L1_f_035(
   uint8_t                                pulse_no,
   uint16_t                               noise_threshold,
   VL53L1_hist_gen4_algo_filtered_data_t *pfiltered,
@@ -474,7 +474,7 @@ VL53L1_Error VL53L1::VL53L1_f_035(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_036(
+VL53L1_Error VL53L1Base::VL53L1_f_036(
   uint8_t   bin,
   int32_t   VL53L1_p_003,
   int32_t   VL53L1_p_018,

--- a/src/vl53l1_hist_char.cpp
+++ b/src/vl53l1_hist_char.cpp
@@ -70,7 +70,7 @@
 #include "vl53l1_class.h"
 
 
-VL53L1_Error VL53L1::VL53L1_set_calib_config(
+VL53L1_Error VL53L1Base::VL53L1_set_calib_config(
   VL53L1_DEV      Dev,
   uint8_t         vcsel_delay__a0,
   uint8_t         calib_1,
@@ -149,7 +149,7 @@ VL53L1_Error VL53L1::VL53L1_set_calib_config(
 
 
 
-VL53L1_Error VL53L1::VL53L1_set_hist_calib_pulse_delay(
+VL53L1_Error VL53L1Base::VL53L1_set_hist_calib_pulse_delay(
   VL53L1_DEV      Dev,
   uint8_t         calib_delay)
 {
@@ -174,7 +174,7 @@ VL53L1_Error VL53L1::VL53L1_set_hist_calib_pulse_delay(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_disable_calib_pulse_delay(
+VL53L1_Error VL53L1Base::VL53L1_disable_calib_pulse_delay(
   VL53L1_DEV      Dev)
 {
 

--- a/src/vl53l1_hist_core.cpp
+++ b/src/vl53l1_hist_core.cpp
@@ -17,7 +17,7 @@
 #include "vl53l1_class.h"
 
 
-void VL53L1::VL53L1_f_013(
+void VL53L1Base::VL53L1_f_013(
   uint8_t                         VL53L1_p_018,
   uint8_t                         filter_woi,
   VL53L1_histogram_bin_data_t    *pbins,
@@ -50,7 +50,7 @@ void VL53L1::VL53L1_f_013(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_011(
+VL53L1_Error VL53L1Base::VL53L1_f_011(
   uint16_t           vcsel_width,
   uint16_t           fast_osc_frequency,
   uint32_t           total_periods_elapsed,
@@ -155,7 +155,7 @@ VL53L1_Error VL53L1::VL53L1_f_011(
 }
 
 
-void VL53L1::VL53L1_f_012(
+void VL53L1Base::VL53L1_f_012(
   uint16_t             gain_factor,
   int16_t              range_offset_mm,
   VL53L1_range_data_t *pdata)
@@ -199,7 +199,7 @@ void VL53L1::VL53L1_f_012(
 }
 
 
-void  VL53L1::VL53L1_f_037(
+void  VL53L1Base::VL53L1_f_037(
   VL53L1_histogram_bin_data_t   *pdata,
   int32_t                        ambient_estimate_counts_per_bin)
 {
@@ -213,7 +213,7 @@ void  VL53L1::VL53L1_f_037(
 }
 
 
-void  VL53L1::VL53L1_f_004(
+void  VL53L1Base::VL53L1_f_004(
   VL53L1_histogram_bin_data_t   *pxtalk,
   VL53L1_histogram_bin_data_t   *pbins,
   VL53L1_histogram_bin_data_t   *pxtalk_realigned)
@@ -292,7 +292,7 @@ void  VL53L1::VL53L1_f_004(
 }
 
 
-int8_t  VL53L1::VL53L1_f_038(
+int8_t  VL53L1Base::VL53L1_f_038(
   VL53L1_histogram_bin_data_t   *pdata1,
   VL53L1_histogram_bin_data_t   *pdata2)
 {
@@ -328,7 +328,7 @@ int8_t  VL53L1::VL53L1_f_038(
 }
 
 
-VL53L1_Error  VL53L1::VL53L1_f_039(
+VL53L1_Error  VL53L1Base::VL53L1_f_039(
   VL53L1_histogram_bin_data_t   *pidata,
   VL53L1_histogram_bin_data_t   *podata)
 {

--- a/src/vl53l1_hist_funcs.cpp
+++ b/src/vl53l1_hist_funcs.cpp
@@ -22,7 +22,7 @@
 #include "vl53l1_class.h"
 
 
-VL53L1_Error VL53L1::VL53L1_hist_process_data(
+VL53L1_Error VL53L1Base::VL53L1_hist_process_data(
   VL53L1_dmax_calibration_data_t     *pdmax_cal,
   VL53L1_hist_gen3_dmax_config_t     *pdmax_cfg,
   VL53L1_hist_post_process_config_t  *ppost_cfg,
@@ -223,7 +223,7 @@ VL53L1_Error VL53L1::VL53L1_hist_process_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_hist_ambient_dmax(
+VL53L1_Error VL53L1Base::VL53L1_hist_ambient_dmax(
   uint16_t                            target_reflectance,
   VL53L1_dmax_calibration_data_t     *pdmax_cal,
   VL53L1_hist_gen3_dmax_config_t     *pdmax_cfg,

--- a/src/vl53l1_nvm.cpp
+++ b/src/vl53l1_nvm.cpp
@@ -66,7 +66,7 @@
 
 
 
-VL53L1_Error VL53L1::VL53L1_nvm_enable(
+VL53L1_Error VL53L1Base::VL53L1_nvm_enable(
   VL53L1_DEV      Dev,
   uint16_t        nvm_ctrl_pulse_width,
   int32_t         nvm_power_up_delay_us)
@@ -142,7 +142,7 @@ VL53L1_Error VL53L1::VL53L1_nvm_enable(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_nvm_read(
+VL53L1_Error VL53L1Base::VL53L1_nvm_read(
   VL53L1_DEV    Dev,
   uint8_t       start_address,
   uint8_t       count,
@@ -205,7 +205,7 @@ VL53L1_Error VL53L1::VL53L1_nvm_read(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_nvm_disable(
+VL53L1_Error VL53L1Base::VL53L1_nvm_disable(
   VL53L1_DEV    Dev)
 {
 
@@ -247,7 +247,7 @@ VL53L1_Error VL53L1::VL53L1_nvm_disable(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_nvm_format_decode(
+VL53L1_Error VL53L1Base::VL53L1_nvm_format_decode(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_decoded_nvm_data_t *pdata)
@@ -833,7 +833,7 @@ VL53L1_Error VL53L1::VL53L1_nvm_format_decode(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_nvm_decode_optical_centre(
+VL53L1_Error VL53L1Base::VL53L1_nvm_decode_optical_centre(
   uint16_t                    buf_size,
   uint8_t                    *pbuffer,
   VL53L1_optical_centre_t    *pdata)
@@ -861,7 +861,7 @@ VL53L1_Error VL53L1::VL53L1_nvm_decode_optical_centre(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_nvm_decode_cal_peak_rate_map(
+VL53L1_Error VL53L1Base::VL53L1_nvm_decode_cal_peak_rate_map(
   uint16_t                    buf_size,
   uint8_t                    *pbuffer,
   VL53L1_cal_peak_rate_map_t *pdata)
@@ -899,7 +899,7 @@ VL53L1_Error VL53L1::VL53L1_nvm_decode_cal_peak_rate_map(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_nvm_decode_additional_offset_cal_data(
+VL53L1_Error VL53L1Base::VL53L1_nvm_decode_additional_offset_cal_data(
   uint16_t                             buf_size,
   uint8_t                             *pbuffer,
   VL53L1_additional_offset_cal_data_t *pdata)
@@ -927,7 +927,7 @@ VL53L1_Error VL53L1::VL53L1_nvm_decode_additional_offset_cal_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_nvm_decode_fmt_range_results_data(
+VL53L1_Error VL53L1Base::VL53L1_nvm_decode_fmt_range_results_data(
   uint16_t                             buf_size,
   uint8_t                             *pbuffer,
   VL53L1_decoded_nvm_fmt_range_data_t *pdata)
@@ -970,7 +970,7 @@ VL53L1_Error VL53L1::VL53L1_nvm_decode_fmt_range_results_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_nvm_decode_fmt_info(
+VL53L1_Error VL53L1Base::VL53L1_nvm_decode_fmt_info(
   uint16_t                       buf_size,
   uint8_t                       *pbuffer,
   VL53L1_decoded_nvm_fmt_info_t *pdata)
@@ -1192,7 +1192,7 @@ VL53L1_Error VL53L1::VL53L1_nvm_decode_fmt_info(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_nvm_decode_ews_info(
+VL53L1_Error VL53L1Base::VL53L1_nvm_decode_ews_info(
   uint16_t                       buf_size,
   uint8_t                       *pbuffer,
   VL53L1_decoded_nvm_ews_info_t *pdata)
@@ -1318,7 +1318,7 @@ VL53L1_Error VL53L1::VL53L1_nvm_decode_ews_info(
 }
 
 
-void VL53L1::VL53L1_nvm_format_encode(
+void VL53L1Base::VL53L1_nvm_format_encode(
   VL53L1_decoded_nvm_data_t *pnvm_info,
   uint8_t                   *pnvm_data)
 {
@@ -1327,7 +1327,7 @@ void VL53L1::VL53L1_nvm_format_encode(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_read_nvm_raw_data(
+VL53L1_Error VL53L1Base::VL53L1_read_nvm_raw_data(
   VL53L1_DEV     Dev,
   uint8_t        start_address,
   uint8_t        count,
@@ -1370,7 +1370,7 @@ VL53L1_Error VL53L1::VL53L1_read_nvm_raw_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_read_nvm(
+VL53L1_Error VL53L1Base::VL53L1_read_nvm(
   VL53L1_DEV                 Dev,
   uint8_t                    nvm_format,
   VL53L1_decoded_nvm_data_t *pnvm_info)
@@ -1412,7 +1412,7 @@ VL53L1_Error VL53L1::VL53L1_read_nvm(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_read_nvm_optical_centre(
+VL53L1_Error VL53L1Base::VL53L1_read_nvm_optical_centre(
   VL53L1_DEV                        Dev,
   VL53L1_optical_centre_t          *pcentre)
 {
@@ -1451,7 +1451,7 @@ VL53L1_Error VL53L1::VL53L1_read_nvm_optical_centre(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_read_nvm_cal_peak_rate_map(
+VL53L1_Error VL53L1Base::VL53L1_read_nvm_cal_peak_rate_map(
   VL53L1_DEV                           Dev,
   VL53L1_cal_peak_rate_map_t          *pcal_data)
 {
@@ -1490,7 +1490,7 @@ VL53L1_Error VL53L1::VL53L1_read_nvm_cal_peak_rate_map(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_read_nvm_additional_offset_cal_data(
+VL53L1_Error VL53L1Base::VL53L1_read_nvm_additional_offset_cal_data(
   VL53L1_DEV                           Dev,
   VL53L1_additional_offset_cal_data_t *pcal_data)
 {
@@ -1530,7 +1530,7 @@ VL53L1_Error VL53L1::VL53L1_read_nvm_additional_offset_cal_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_read_nvm_fmt_range_results_data(
+VL53L1_Error VL53L1Base::VL53L1_read_nvm_fmt_range_results_data(
   VL53L1_DEV                           Dev,
   uint16_t                             range_results_select,
   VL53L1_decoded_nvm_fmt_range_data_t *prange_data)

--- a/src/vl53l1_platform_ipp.cpp
+++ b/src/vl53l1_platform_ipp.cpp
@@ -37,7 +37,7 @@
 #include "vl53l1_class.h"
 
 
-VL53L1_Error VL53L1::VL53L1_ipp_hist_process_data(
+VL53L1_Error VL53L1Base::VL53L1_ipp_hist_process_data(
   VL53L1_DEV                         Dev,
   VL53L1_dmax_calibration_data_t    *pdmax_cal,
   VL53L1_hist_gen3_dmax_config_t    *pdmax_cfg,
@@ -71,7 +71,7 @@ VL53L1_Error VL53L1::VL53L1_ipp_hist_process_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_ipp_hist_ambient_dmax(
+VL53L1_Error VL53L1Base::VL53L1_ipp_hist_ambient_dmax(
   VL53L1_DEV                         Dev,
   uint16_t                           target_reflectance,
   VL53L1_dmax_calibration_data_t    *pdmax_cal,
@@ -97,7 +97,7 @@ VL53L1_Error VL53L1::VL53L1_ipp_hist_ambient_dmax(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_ipp_xtalk_calibration_process_data(
+VL53L1_Error VL53L1Base::VL53L1_ipp_xtalk_calibration_process_data(
   VL53L1_DEV                          Dev,
   VL53L1_xtalk_range_results_t       *pxtalk_ranges,
   VL53L1_xtalk_histogram_data_t      *pxtalk_shape,
@@ -118,7 +118,7 @@ VL53L1_Error VL53L1::VL53L1_ipp_xtalk_calibration_process_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_ipp_hist_xtalk_correction(
+VL53L1_Error VL53L1Base::VL53L1_ipp_hist_xtalk_correction(
   VL53L1_DEV                     Dev,
   VL53L1_customer_nvm_managed_t *pcustomer,
   VL53L1_dynamic_config_t       *pdyn_cfg,
@@ -144,7 +144,7 @@ VL53L1_Error VL53L1::VL53L1_ipp_hist_xtalk_correction(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_ipp_generate_dual_reflectance_xtalk_samples(
+VL53L1_Error VL53L1Base::VL53L1_ipp_generate_dual_reflectance_xtalk_samples(
   VL53L1_DEV                     Dev,
   VL53L1_xtalk_range_results_t  *pxtalk_results,
   uint16_t                 expected_target_distance_mm,

--- a/src/vl53l1_register_funcs.cpp
+++ b/src/vl53l1_register_funcs.cpp
@@ -68,7 +68,7 @@
 #include "vl53l1_class.h"
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_static_nvm_managed(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_static_nvm_managed(
   VL53L1_static_nvm_managed_t *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -112,7 +112,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_static_nvm_managed(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_static_nvm_managed(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_static_nvm_managed(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_static_nvm_managed_t  *pdata)
@@ -154,7 +154,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_static_nvm_managed(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_static_nvm_managed(
+VL53L1_Error VL53L1Base::VL53L1_set_static_nvm_managed(
   VL53L1_DEV                 Dev,
   VL53L1_static_nvm_managed_t  *pdata)
 {
@@ -184,7 +184,7 @@ VL53L1_Error VL53L1::VL53L1_set_static_nvm_managed(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_static_nvm_managed(
+VL53L1_Error VL53L1Base::VL53L1_get_static_nvm_managed(
   VL53L1_DEV                 Dev,
   VL53L1_static_nvm_managed_t  *pdata)
 {
@@ -214,7 +214,7 @@ VL53L1_Error VL53L1::VL53L1_get_static_nvm_managed(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_customer_nvm_managed(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_customer_nvm_managed(
   VL53L1_customer_nvm_managed_t *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -282,7 +282,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_customer_nvm_managed(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_customer_nvm_managed(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_customer_nvm_managed(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_customer_nvm_managed_t  *pdata)
@@ -336,7 +336,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_customer_nvm_managed(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_customer_nvm_managed(
+VL53L1_Error VL53L1Base::VL53L1_set_customer_nvm_managed(
   VL53L1_DEV                 Dev,
   VL53L1_customer_nvm_managed_t  *pdata)
 {
@@ -366,7 +366,7 @@ VL53L1_Error VL53L1::VL53L1_set_customer_nvm_managed(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_customer_nvm_managed(
+VL53L1_Error VL53L1Base::VL53L1_get_customer_nvm_managed(
   VL53L1_DEV                 Dev,
   VL53L1_customer_nvm_managed_t  *pdata)
 {
@@ -396,7 +396,7 @@ VL53L1_Error VL53L1::VL53L1_get_customer_nvm_managed(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_static_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_static_config(
   VL53L1_static_config_t   *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -482,7 +482,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_static_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_static_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_static_config(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_static_config_t    *pdata)
@@ -564,7 +564,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_static_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_static_config(
+VL53L1_Error VL53L1Base::VL53L1_set_static_config(
   VL53L1_DEV                 Dev,
   VL53L1_static_config_t    *pdata)
 {
@@ -594,7 +594,7 @@ VL53L1_Error VL53L1::VL53L1_set_static_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_static_config(
+VL53L1_Error VL53L1Base::VL53L1_get_static_config(
   VL53L1_DEV                 Dev,
   VL53L1_static_config_t    *pdata)
 {
@@ -624,7 +624,7 @@ VL53L1_Error VL53L1::VL53L1_get_static_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_general_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_general_config(
   VL53L1_general_config_t  *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -688,7 +688,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_general_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_general_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_general_config(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_general_config_t   *pdata)
@@ -744,7 +744,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_general_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_general_config(
+VL53L1_Error VL53L1Base::VL53L1_set_general_config(
   VL53L1_DEV                 Dev,
   VL53L1_general_config_t   *pdata)
 {
@@ -774,7 +774,7 @@ VL53L1_Error VL53L1::VL53L1_set_general_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_general_config(
+VL53L1_Error VL53L1Base::VL53L1_get_general_config(
   VL53L1_DEV                 Dev,
   VL53L1_general_config_t   *pdata)
 {
@@ -804,7 +804,7 @@ VL53L1_Error VL53L1::VL53L1_get_general_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_timing_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_timing_config(
   VL53L1_timing_config_t   *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -864,7 +864,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_timing_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_timing_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_timing_config(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_timing_config_t    *pdata)
@@ -918,7 +918,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_timing_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_timing_config(
+VL53L1_Error VL53L1Base::VL53L1_set_timing_config(
   VL53L1_DEV                 Dev,
   VL53L1_timing_config_t    *pdata)
 {
@@ -948,7 +948,7 @@ VL53L1_Error VL53L1::VL53L1_set_timing_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_timing_config(
+VL53L1_Error VL53L1Base::VL53L1_get_timing_config(
   VL53L1_DEV                 Dev,
   VL53L1_timing_config_t    *pdata)
 {
@@ -978,7 +978,7 @@ VL53L1_Error VL53L1::VL53L1_get_timing_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_dynamic_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_dynamic_config(
   VL53L1_dynamic_config_t  *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -1036,7 +1036,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_dynamic_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_dynamic_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_dynamic_config(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_dynamic_config_t   *pdata)
@@ -1090,7 +1090,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_dynamic_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_dynamic_config(
+VL53L1_Error VL53L1Base::VL53L1_set_dynamic_config(
   VL53L1_DEV                 Dev,
   VL53L1_dynamic_config_t   *pdata)
 {
@@ -1120,7 +1120,7 @@ VL53L1_Error VL53L1::VL53L1_set_dynamic_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_dynamic_config(
+VL53L1_Error VL53L1Base::VL53L1_get_dynamic_config(
   VL53L1_DEV                 Dev,
   VL53L1_dynamic_config_t   *pdata)
 {
@@ -1150,7 +1150,7 @@ VL53L1_Error VL53L1::VL53L1_get_dynamic_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_system_control(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_system_control(
   VL53L1_system_control_t  *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -1182,7 +1182,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_system_control(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_system_control(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_system_control(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_system_control_t   *pdata)
@@ -1214,7 +1214,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_system_control(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_system_control(
+VL53L1_Error VL53L1Base::VL53L1_set_system_control(
   VL53L1_DEV                 Dev,
   VL53L1_system_control_t   *pdata)
 {
@@ -1244,7 +1244,7 @@ VL53L1_Error VL53L1::VL53L1_set_system_control(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_system_control(
+VL53L1_Error VL53L1Base::VL53L1_get_system_control(
   VL53L1_DEV                 Dev,
   VL53L1_system_control_t   *pdata)
 {
@@ -1274,7 +1274,7 @@ VL53L1_Error VL53L1::VL53L1_get_system_control(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_system_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_system_results(
   VL53L1_system_results_t  *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -1384,7 +1384,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_system_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_system_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_system_results(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_system_results_t   *pdata)
@@ -1456,7 +1456,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_system_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_system_results(
+VL53L1_Error VL53L1Base::VL53L1_set_system_results(
   VL53L1_DEV                 Dev,
   VL53L1_system_results_t   *pdata)
 {
@@ -1486,7 +1486,7 @@ VL53L1_Error VL53L1::VL53L1_set_system_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_system_results(
+VL53L1_Error VL53L1Base::VL53L1_get_system_results(
   VL53L1_DEV                 Dev,
   VL53L1_system_results_t   *pdata)
 {
@@ -1516,7 +1516,7 @@ VL53L1_Error VL53L1::VL53L1_get_system_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_core_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_core_results(
   VL53L1_core_results_t    *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -1572,7 +1572,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_core_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_core_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_core_results(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_core_results_t     *pdata)
@@ -1612,7 +1612,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_core_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_core_results(
+VL53L1_Error VL53L1Base::VL53L1_set_core_results(
   VL53L1_DEV                 Dev,
   VL53L1_core_results_t     *pdata)
 {
@@ -1650,7 +1650,7 @@ VL53L1_Error VL53L1::VL53L1_set_core_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_core_results(
+VL53L1_Error VL53L1Base::VL53L1_get_core_results(
   VL53L1_DEV                 Dev,
   VL53L1_core_results_t     *pdata)
 {
@@ -1680,7 +1680,7 @@ VL53L1_Error VL53L1::VL53L1_get_core_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_debug_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_debug_results(
   VL53L1_debug_results_t   *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -1802,7 +1802,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_debug_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_debug_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_debug_results(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_debug_results_t    *pdata)
@@ -1910,7 +1910,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_debug_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_debug_results(
+VL53L1_Error VL53L1Base::VL53L1_set_debug_results(
   VL53L1_DEV                 Dev,
   VL53L1_debug_results_t    *pdata)
 {
@@ -1948,7 +1948,7 @@ VL53L1_Error VL53L1::VL53L1_set_debug_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_debug_results(
+VL53L1_Error VL53L1Base::VL53L1_get_debug_results(
   VL53L1_DEV                 Dev,
   VL53L1_debug_results_t    *pdata)
 {
@@ -1978,7 +1978,7 @@ VL53L1_Error VL53L1::VL53L1_get_debug_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_nvm_copy_data(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_nvm_copy_data(
   VL53L1_nvm_copy_data_t   *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -2098,7 +2098,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_nvm_copy_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_nvm_copy_data(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_nvm_copy_data(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_nvm_copy_data_t    *pdata)
@@ -2216,7 +2216,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_nvm_copy_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_nvm_copy_data(
+VL53L1_Error VL53L1Base::VL53L1_set_nvm_copy_data(
   VL53L1_DEV                 Dev,
   VL53L1_nvm_copy_data_t    *pdata)
 {
@@ -2254,7 +2254,7 @@ VL53L1_Error VL53L1::VL53L1_set_nvm_copy_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_nvm_copy_data(
+VL53L1_Error VL53L1Base::VL53L1_get_nvm_copy_data(
   VL53L1_DEV                 Dev,
   VL53L1_nvm_copy_data_t    *pdata)
 {
@@ -2284,7 +2284,7 @@ VL53L1_Error VL53L1::VL53L1_get_nvm_copy_data(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_prev_shadow_system_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_prev_shadow_system_results(
   VL53L1_prev_shadow_system_results_t *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -2394,7 +2394,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_prev_shadow_system_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_prev_shadow_system_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_prev_shadow_system_results(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_prev_shadow_system_results_t  *pdata)
@@ -2464,7 +2464,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_prev_shadow_system_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_prev_shadow_system_results(
+VL53L1_Error VL53L1Base::VL53L1_set_prev_shadow_system_results(
   VL53L1_DEV                 Dev,
   VL53L1_prev_shadow_system_results_t  *pdata)
 {
@@ -2502,7 +2502,7 @@ VL53L1_Error VL53L1::VL53L1_set_prev_shadow_system_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_prev_shadow_system_results(
+VL53L1_Error VL53L1Base::VL53L1_get_prev_shadow_system_results(
   VL53L1_DEV                 Dev,
   VL53L1_prev_shadow_system_results_t  *pdata)
 {
@@ -2540,7 +2540,7 @@ VL53L1_Error VL53L1::VL53L1_get_prev_shadow_system_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_prev_shadow_core_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_prev_shadow_core_results(
   VL53L1_prev_shadow_core_results_t *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -2596,7 +2596,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_prev_shadow_core_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_prev_shadow_core_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_prev_shadow_core_results(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_prev_shadow_core_results_t  *pdata)
@@ -2636,7 +2636,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_prev_shadow_core_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_prev_shadow_core_results(
+VL53L1_Error VL53L1Base::VL53L1_set_prev_shadow_core_results(
   VL53L1_DEV                 Dev,
   VL53L1_prev_shadow_core_results_t  *pdata)
 {
@@ -2674,7 +2674,7 @@ VL53L1_Error VL53L1::VL53L1_set_prev_shadow_core_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_prev_shadow_core_results(
+VL53L1_Error VL53L1Base::VL53L1_get_prev_shadow_core_results(
   VL53L1_DEV                 Dev,
   VL53L1_prev_shadow_core_results_t  *pdata)
 {
@@ -2712,7 +2712,7 @@ VL53L1_Error VL53L1::VL53L1_get_prev_shadow_core_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_patch_debug(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_patch_debug(
   VL53L1_patch_debug_t     *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -2738,7 +2738,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_patch_debug(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_patch_debug(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_patch_debug(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_patch_debug_t      *pdata)
@@ -2764,7 +2764,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_patch_debug(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_patch_debug(
+VL53L1_Error VL53L1Base::VL53L1_set_patch_debug(
   VL53L1_DEV                 Dev,
   VL53L1_patch_debug_t      *pdata)
 {
@@ -2802,7 +2802,7 @@ VL53L1_Error VL53L1::VL53L1_set_patch_debug(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_patch_debug(
+VL53L1_Error VL53L1Base::VL53L1_get_patch_debug(
   VL53L1_DEV                 Dev,
   VL53L1_patch_debug_t      *pdata)
 {
@@ -2840,7 +2840,7 @@ VL53L1_Error VL53L1::VL53L1_get_patch_debug(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_gph_general_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_gph_general_config(
   VL53L1_gph_general_config_t *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -2872,7 +2872,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_gph_general_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_gph_general_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_gph_general_config(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_gph_general_config_t  *pdata)
@@ -2900,7 +2900,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_gph_general_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_gph_general_config(
+VL53L1_Error VL53L1Base::VL53L1_set_gph_general_config(
   VL53L1_DEV                 Dev,
   VL53L1_gph_general_config_t  *pdata)
 {
@@ -2938,7 +2938,7 @@ VL53L1_Error VL53L1::VL53L1_set_gph_general_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_gph_general_config(
+VL53L1_Error VL53L1Base::VL53L1_get_gph_general_config(
   VL53L1_DEV                 Dev,
   VL53L1_gph_general_config_t  *pdata)
 {
@@ -2976,7 +2976,7 @@ VL53L1_Error VL53L1::VL53L1_get_gph_general_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_gph_static_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_gph_static_config(
   VL53L1_gph_static_config_t *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -3010,7 +3010,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_gph_static_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_gph_static_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_gph_static_config(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_gph_static_config_t  *pdata)
@@ -3042,7 +3042,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_gph_static_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_gph_static_config(
+VL53L1_Error VL53L1Base::VL53L1_set_gph_static_config(
   VL53L1_DEV                 Dev,
   VL53L1_gph_static_config_t  *pdata)
 {
@@ -3080,7 +3080,7 @@ VL53L1_Error VL53L1::VL53L1_set_gph_static_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_gph_static_config(
+VL53L1_Error VL53L1Base::VL53L1_get_gph_static_config(
   VL53L1_DEV                 Dev,
   VL53L1_gph_static_config_t  *pdata)
 {
@@ -3118,7 +3118,7 @@ VL53L1_Error VL53L1::VL53L1_get_gph_static_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_gph_timing_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_gph_timing_config(
   VL53L1_gph_timing_config_t *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -3172,7 +3172,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_gph_timing_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_gph_timing_config(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_gph_timing_config(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_gph_timing_config_t  *pdata)
@@ -3222,7 +3222,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_gph_timing_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_gph_timing_config(
+VL53L1_Error VL53L1Base::VL53L1_set_gph_timing_config(
   VL53L1_DEV                 Dev,
   VL53L1_gph_timing_config_t  *pdata)
 {
@@ -3260,7 +3260,7 @@ VL53L1_Error VL53L1::VL53L1_set_gph_timing_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_gph_timing_config(
+VL53L1_Error VL53L1Base::VL53L1_get_gph_timing_config(
   VL53L1_DEV                 Dev,
   VL53L1_gph_timing_config_t  *pdata)
 {
@@ -3298,7 +3298,7 @@ VL53L1_Error VL53L1::VL53L1_get_gph_timing_config(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_fw_internal(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_fw_internal(
   VL53L1_fw_internal_t     *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -3324,7 +3324,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_fw_internal(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_fw_internal(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_fw_internal(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_fw_internal_t      *pdata)
@@ -3350,7 +3350,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_fw_internal(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_fw_internal(
+VL53L1_Error VL53L1Base::VL53L1_set_fw_internal(
   VL53L1_DEV                 Dev,
   VL53L1_fw_internal_t      *pdata)
 {
@@ -3388,7 +3388,7 @@ VL53L1_Error VL53L1::VL53L1_set_fw_internal(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_fw_internal(
+VL53L1_Error VL53L1Base::VL53L1_get_fw_internal(
   VL53L1_DEV                 Dev,
   VL53L1_fw_internal_t      *pdata)
 {
@@ -3426,7 +3426,7 @@ VL53L1_Error VL53L1::VL53L1_get_fw_internal(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_patch_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_patch_results(
   VL53L1_patch_results_t   *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -3596,7 +3596,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_patch_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_patch_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_patch_results(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_patch_results_t    *pdata)
@@ -3738,7 +3738,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_patch_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_patch_results(
+VL53L1_Error VL53L1Base::VL53L1_set_patch_results(
   VL53L1_DEV                 Dev,
   VL53L1_patch_results_t    *pdata)
 {
@@ -3776,7 +3776,7 @@ VL53L1_Error VL53L1::VL53L1_set_patch_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_patch_results(
+VL53L1_Error VL53L1Base::VL53L1_get_patch_results(
   VL53L1_DEV                 Dev,
   VL53L1_patch_results_t    *pdata)
 {
@@ -3814,7 +3814,7 @@ VL53L1_Error VL53L1::VL53L1_get_patch_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_shadow_system_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_shadow_system_results(
   VL53L1_shadow_system_results_t *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -3930,7 +3930,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_shadow_system_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_shadow_system_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_shadow_system_results(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_shadow_system_results_t  *pdata)
@@ -4008,7 +4008,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_shadow_system_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_shadow_system_results(
+VL53L1_Error VL53L1Base::VL53L1_set_shadow_system_results(
   VL53L1_DEV                 Dev,
   VL53L1_shadow_system_results_t  *pdata)
 {
@@ -4046,7 +4046,7 @@ VL53L1_Error VL53L1::VL53L1_set_shadow_system_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_shadow_system_results(
+VL53L1_Error VL53L1Base::VL53L1_get_shadow_system_results(
   VL53L1_DEV                 Dev,
   VL53L1_shadow_system_results_t  *pdata)
 {
@@ -4084,7 +4084,7 @@ VL53L1_Error VL53L1::VL53L1_get_shadow_system_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_encode_shadow_core_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_encode_shadow_core_results(
   VL53L1_shadow_core_results_t *pdata,
   uint16_t                  buf_size,
   uint8_t                  *pbuffer)
@@ -4140,7 +4140,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_encode_shadow_core_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_i2c_decode_shadow_core_results(
+VL53L1_Error VL53L1Base::VL53L1_i2c_decode_shadow_core_results(
   uint16_t                   buf_size,
   uint8_t                   *pbuffer,
   VL53L1_shadow_core_results_t  *pdata)
@@ -4180,7 +4180,7 @@ VL53L1_Error VL53L1::VL53L1_i2c_decode_shadow_core_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_set_shadow_core_results(
+VL53L1_Error VL53L1Base::VL53L1_set_shadow_core_results(
   VL53L1_DEV                 Dev,
   VL53L1_shadow_core_results_t  *pdata)
 {
@@ -4218,7 +4218,7 @@ VL53L1_Error VL53L1::VL53L1_set_shadow_core_results(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_get_shadow_core_results(
+VL53L1_Error VL53L1Base::VL53L1_get_shadow_core_results(
   VL53L1_DEV                 Dev,
   VL53L1_shadow_core_results_t  *pdata)
 {

--- a/src/vl53l1_sigma_estimate.cpp
+++ b/src/vl53l1_sigma_estimate.cpp
@@ -19,7 +19,7 @@
 #include "vl53l1_class.h"
 
 
-uint16_t  VL53L1::VL53L1_f_042(
+uint16_t  VL53L1Base::VL53L1_f_042(
   uint8_t  sigma_estimator__effective_pulse_width_ns,
   uint8_t  sigma_estimator__effective_ambient_width_ns,
   uint8_t  sigma_estimator__sigma_ref_mm,
@@ -101,7 +101,7 @@ uint16_t  VL53L1::VL53L1_f_042(
 }
 
 
-uint16_t VL53L1::VL53L1_f_044(
+uint16_t VL53L1Base::VL53L1_f_044(
   uint8_t  sigma_estimator__effective_pulse_width_ns,
   uint8_t  sigma_estimator__effective_ambient_width_ns,
   uint8_t  sigma_estimator__sigma_ref_mm,
@@ -169,7 +169,7 @@ uint16_t VL53L1::VL53L1_f_044(
 
 
 
-VL53L1_Error VL53L1::VL53L1_f_045(
+VL53L1_Error VL53L1Base::VL53L1_f_045(
   uint8_t  sigma_estimator__sigma_ref_mm,
   uint32_t VL53L1_p_003,
   uint32_t VL53L1_p_018,
@@ -293,7 +293,7 @@ VL53L1_Error VL53L1::VL53L1_f_045(
 
 
 
-VL53L1_Error VL53L1::VL53L1_f_014(
+VL53L1_Error VL53L1Base::VL53L1_f_014(
   uint8_t  sigma_estimator__sigma_ref_mm,
   uint32_t VL53L1_p_003,
   uint32_t VL53L1_p_018,
@@ -465,7 +465,7 @@ VL53L1_Error VL53L1::VL53L1_f_014(
   return status;
 }
 
-uint32_t VL53L1::VL53L1_f_046(
+uint32_t VL53L1Base::VL53L1_f_046(
   uint64_t VL53L1_p_003,
   uint32_t size
 )
@@ -507,7 +507,7 @@ uint32_t VL53L1::VL53L1_f_046(
 
 
 
-uint32_t VL53L1::VL53L1_f_043(
+uint32_t VL53L1Base::VL53L1_f_043(
   uint32_t VL53L1_p_003,
   uint32_t VL53L1_p_018)
 {

--- a/src/vl53l1_silicon_core.cpp
+++ b/src/vl53l1_silicon_core.cpp
@@ -70,7 +70,7 @@
 
 
 
-VL53L1_Error VL53L1::VL53L1_is_firmware_ready_silicon(
+VL53L1_Error VL53L1Base::VL53L1_is_firmware_ready_silicon(
   VL53L1_DEV     Dev,
   uint8_t       *pready)
 {

--- a/src/vl53l1_wait.cpp
+++ b/src/vl53l1_wait.cpp
@@ -70,7 +70,7 @@
 
 
 
-VL53L1_Error VL53L1::VL53L1_wait_for_boot_completion(
+VL53L1_Error VL53L1Base::VL53L1_wait_for_boot_completion(
   VL53L1_DEV     Dev)
 {
 
@@ -117,7 +117,7 @@ VL53L1_Error VL53L1::VL53L1_wait_for_boot_completion(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_wait_for_firmware_ready(
+VL53L1_Error VL53L1Base::VL53L1_wait_for_firmware_ready(
   VL53L1_DEV     Dev)
 {
 
@@ -176,7 +176,7 @@ VL53L1_Error VL53L1::VL53L1_wait_for_firmware_ready(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_wait_for_range_completion(
+VL53L1_Error VL53L1Base::VL53L1_wait_for_range_completion(
   VL53L1_DEV     Dev)
 {
 
@@ -222,7 +222,7 @@ VL53L1_Error VL53L1::VL53L1_wait_for_range_completion(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_wait_for_test_completion(
+VL53L1_Error VL53L1Base::VL53L1_wait_for_test_completion(
   VL53L1_DEV     Dev)
 {
 
@@ -270,7 +270,7 @@ VL53L1_Error VL53L1::VL53L1_wait_for_test_completion(
 
 
 
-VL53L1_Error VL53L1::VL53L1_is_boot_complete(
+VL53L1_Error VL53L1Base::VL53L1_is_boot_complete(
   VL53L1_DEV     Dev,
   uint8_t       *pready)
 {
@@ -309,7 +309,7 @@ VL53L1_Error VL53L1::VL53L1_is_boot_complete(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_is_firmware_ready(
+VL53L1_Error VL53L1Base::VL53L1_is_firmware_ready(
   VL53L1_DEV     Dev,
   uint8_t       *pready)
 {
@@ -332,7 +332,7 @@ VL53L1_Error VL53L1::VL53L1_is_firmware_ready(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_is_new_data_ready(
+VL53L1_Error VL53L1Base::VL53L1_is_new_data_ready(
   VL53L1_DEV     Dev,
   uint8_t       *pready)
 {
@@ -380,7 +380,7 @@ VL53L1_Error VL53L1::VL53L1_is_new_data_ready(
 
 
 
-VL53L1_Error VL53L1::VL53L1_poll_for_boot_completion(
+VL53L1_Error VL53L1Base::VL53L1_poll_for_boot_completion(
   VL53L1_DEV    Dev,
   uint32_t      timeout_ms)
 {
@@ -416,7 +416,7 @@ VL53L1_Error VL53L1::VL53L1_poll_for_boot_completion(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_poll_for_firmware_ready(
+VL53L1_Error VL53L1Base::VL53L1_poll_for_firmware_ready(
   VL53L1_DEV    Dev,
   uint32_t      timeout_ms)
 {
@@ -469,7 +469,7 @@ VL53L1_Error VL53L1::VL53L1_poll_for_firmware_ready(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_poll_for_range_completion(
+VL53L1_Error VL53L1Base::VL53L1_poll_for_range_completion(
   VL53L1_DEV     Dev,
   uint32_t       timeout_ms)
 {

--- a/src/vl53l1_xtalk.cpp
+++ b/src/vl53l1_xtalk.cpp
@@ -19,7 +19,7 @@
 #include "vl53l1_class.h"
 
 
-VL53L1_Error VL53L1::VL53L1_xtalk_calibration_process_data(
+VL53L1_Error VL53L1Base::VL53L1_xtalk_calibration_process_data(
   VL53L1_xtalk_range_results_t    *pxtalk_results,
   VL53L1_xtalk_histogram_data_t   *pxtalk_shape,
   VL53L1_xtalk_calibration_results_t  *pxtalk_cal)
@@ -125,7 +125,7 @@ ENDFUNC:
 }
 
 
-VL53L1_Error VL53L1::VL53L1_generate_dual_reflectance_xtalk_samples(
+VL53L1_Error VL53L1Base::VL53L1_generate_dual_reflectance_xtalk_samples(
   VL53L1_xtalk_range_results_t  *pxtalk_results,
   uint16_t      expected_target_distance_mm,
   uint8_t         higher_reflectance,
@@ -197,7 +197,7 @@ VL53L1_Error VL53L1::VL53L1_generate_dual_reflectance_xtalk_samples(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_050(
+VL53L1_Error VL53L1Base::VL53L1_f_050(
   VL53L1_histogram_bin_data_t *pzone_avg_1,
   VL53L1_histogram_bin_data_t *pzone_avg_2,
   uint16_t      expected_target_distance,
@@ -272,7 +272,7 @@ VL53L1_Error VL53L1::VL53L1_f_050(
   return status;
 }
 
-VL53L1_Error VL53L1::VL53L1_f_049(
+VL53L1_Error VL53L1Base::VL53L1_f_049(
   VL53L1_histogram_bin_data_t        *pavg_bins,
   VL53L1_xtalk_algo_data_t           *pdebug,
   VL53L1_xtalk_range_data_t          *pxtalk_data,
@@ -328,7 +328,7 @@ VL53L1_Error VL53L1::VL53L1_f_049(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_047(
+VL53L1_Error VL53L1Base::VL53L1_f_047(
   VL53L1_xtalk_range_results_t   *pxtalk_results,
   VL53L1_xtalk_algo_data_t       *pdebug,
   int16_t                        *xgradient,
@@ -461,7 +461,7 @@ VL53L1_Error VL53L1::VL53L1_f_047(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_048(
+VL53L1_Error VL53L1Base::VL53L1_f_048(
   VL53L1_xtalk_range_data_t *pxtalk_data,
   VL53L1_xtalk_algo_data_t  *pdebug,
   uint32_t                 *xtalk_mean_offset_kcps
@@ -527,7 +527,7 @@ VL53L1_Error VL53L1::VL53L1_f_048(
 
 
 
-VL53L1_Error VL53L1::VL53L1_f_053(
+VL53L1_Error VL53L1Base::VL53L1_f_053(
   VL53L1_histogram_bin_data_t *phist_data,
   VL53L1_xtalk_range_data_t      *pxtalk_data,
   VL53L1_xtalk_algo_data_t       *pdebug,
@@ -624,7 +624,7 @@ FAIL:
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_054(
+VL53L1_Error VL53L1Base::VL53L1_f_054(
   VL53L1_customer_nvm_managed_t *pcustomer,
   VL53L1_dynamic_config_t       *pdyn_cfg,
   VL53L1_xtalk_histogram_data_t *pxtalk_shape,
@@ -688,7 +688,7 @@ VL53L1_Error VL53L1::VL53L1_f_054(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_040(
+VL53L1_Error VL53L1Base::VL53L1_f_040(
   uint32_t                       mean_offset,
   int16_t                        xgradient,
   int16_t                        ygradient,
@@ -818,7 +818,7 @@ VL53L1_Error VL53L1::VL53L1_f_040(
 
 
 
-VL53L1_Error VL53L1::VL53L1_f_041(
+VL53L1_Error VL53L1Base::VL53L1_f_041(
   VL53L1_histogram_bin_data_t    *phist_data,
   VL53L1_xtalk_histogram_shape_t *pxtalk_data,
   uint32_t                        xtalk_rate_kcps,
@@ -877,7 +877,7 @@ VL53L1_Error VL53L1::VL53L1_f_041(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_055(
+VL53L1_Error VL53L1Base::VL53L1_f_055(
   VL53L1_histogram_bin_data_t *phist_data,
   VL53L1_histogram_bin_data_t *pxtalk_data,
   uint8_t         xtalk_bin_offset)
@@ -916,7 +916,7 @@ VL53L1_Error VL53L1::VL53L1_f_055(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_052(
+VL53L1_Error VL53L1Base::VL53L1_f_052(
   VL53L1_histogram_bin_data_t   *pxtalk_data,
   uint32_t            amb_threshold,
   uint8_t           VL53L1_p_022,
@@ -1035,7 +1035,7 @@ VL53L1_Error VL53L1::VL53L1_f_052(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_f_051(
+VL53L1_Error VL53L1Base::VL53L1_f_051(
   uint8_t                      sigma_mult,
   int32_t                      VL53L1_p_004,
   uint32_t                    *ambient_noise)

--- a/src/vl53l1_zone_presets.cpp
+++ b/src/vl53l1_zone_presets.cpp
@@ -68,7 +68,7 @@
 #include "vl53l1_class.h"
 
 
-VL53L1_Error VL53L1::VL53L1_init_zone_config_structure(
+VL53L1_Error VL53L1Base::VL53L1_init_zone_config_structure(
   uint8_t x_off,
   uint8_t x_inc,
   uint8_t x_zones,
@@ -117,7 +117,7 @@ VL53L1_Error VL53L1::VL53L1_init_zone_config_structure(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_zone_preset_xtalk_planar(
+VL53L1_Error VL53L1Base::VL53L1_zone_preset_xtalk_planar(
   VL53L1_general_config_t *pgeneral,
   VL53L1_zone_config_t    *pzone_cfg)
 {
@@ -166,7 +166,7 @@ VL53L1_Error VL53L1::VL53L1_zone_preset_xtalk_planar(
 }
 
 
-VL53L1_Error VL53L1::VL53L1_init_zone_config_histogram_bins(
+VL53L1_Error VL53L1Base::VL53L1_init_zone_config_histogram_bins(
   VL53L1_zone_config_t   *pdata)
 {
 


### PR DESCRIPTION
In order to use many VL53L1 range sensors, the same number of Xshutdown pins (XSHUT, aka GPIO0) need to be controlled. In case the number of available general purpose output pins on the host microcontroller is not sufficient, the pins must be controlled indirectly. For example using an IO expander or a shift register.

This pull request introduces a possibility to define a subclass which does control the Xshutdown pin of the sensor using a different method. In particular the base class does not require a pin number on creation and does not store such number as member.

Although the *previous class definition* allows to override the relevant member functions (`begin()`, `end()`, `VL53L1_On()`, `VL53L1_Off()`) it has some drawbacks:

 - The invariant part of the overall algorithm, which is not specific on the control method for the pin, must be copied into the 
    overriding function definition. In particular `delay(10);`.
 - The subclass does contain the (inherited) member `gpio0` which may not be used.

Instead the previous class `VL53L1` has been designated as base class, agnostic of the method on how to control the Xshutdown pins. This class has been renamed to `VL53L1Base`. It has new private pure virtual helper functions which are used by the relevant member functions (listed above) to set the XSHUT pin high/low, initialize and de-initialize the control mechanism to XSHUT.

A new class called `VL53L1` has been defined which does inherit from `VL53L1Base` and realizes the new helper functions. The helper functions implement the control of the Xshutdown signal using a GPIO number, exactly as the former class `VL53L1` did.

The result is the following:

 - there is still a class `VL53L1` which does exactly the same as previously
 - there is an additional abstract class `VL53L1Base` which requires the helper functions for the Xshutdown control to be realized

The suggested changes attempt to provide a base class which can be used to control XSHUT in different ways. Without the need to pay attention to the overall algorithm or providing and storing a pin number if not necessary.

The pull request changes many files, as the former class `VL53L1` is renamed to `VL53L1Base`. The interesting change occurs in the `vl53l1_class.*` files.