### PR TITLE
Add possibility to customize default configuration.

### DIFF
--- a/src/vl53l1_platform_user_config.h
+++ b/src/vl53l1_platform_user_config.h
@@ -30,67 +30,113 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * @file  vl53l1_platform_user_config.h
  *
  * @brief EwokPlus compile time user modifiable configuration
+ *
+ * The default configuration values may be customized without modifying the library code by either:
+ *
+ * - Predefining the macro using a preprocessor option.
+ *   Using Arduino IDE this can be achieved with help of the
+ *   [`platform.local.txt`](https://arduino.github.io/arduino-cli/0.20/platform-specification/#platformlocaltxt)
+ *   configuration file.
+ *   For example to change the value of `VL53L1_MAX_RANGE_RESULTS` to `1` add this line to
+ *   `platform.local.txt`:
+ *   ```
+ *   compiler.cpp.extra_flags=-DVL53L1_MAX_RANGE_RESULTS=1
+ *   ```
  */
 
 
 #ifndef _VL53L1_PLATFORM_USER_CONFIG_H_
 #define _VL53L1_PLATFORM_USER_CONFIG_H_
 
+#ifndef VL53L1_BYTES_PER_WORD
 #define    VL53L1_BYTES_PER_WORD              2
+#endif
+#ifndef VL53L1_BYTES_PER_DWORD
 #define    VL53L1_BYTES_PER_DWORD             4
+#endif
 
 /* Define polling delays */
+#ifndef VL53L1_BOOT_COMPLETION_POLLING_TIMEOUT_MS
 #define VL53L1_BOOT_COMPLETION_POLLING_TIMEOUT_MS     500
+#endif
+#ifndef VL53L1_RANGE_COMPLETION_POLLING_TIMEOUT_MS
 #define VL53L1_RANGE_COMPLETION_POLLING_TIMEOUT_MS   2000
+#endif
+#ifndef VL53L1_TEST_COMPLETION_POLLING_TIMEOUT_MS
 #define VL53L1_TEST_COMPLETION_POLLING_TIMEOUT_MS   10000
+#endif
 
+#ifndef VL53L1_POLLING_DELAY_MS
 #define VL53L1_POLLING_DELAY_MS                         1
+#endif
 
 /* Define LLD TuningParms Page Base Address
  * - Part of Patch_AddedTuningParms_11761
  */
+#ifndef VL53L1_TUNINGPARM_PUBLIC_PAGE_BASE_ADDRESS
 #define VL53L1_TUNINGPARM_PUBLIC_PAGE_BASE_ADDRESS  0x8000
+#endif
+#ifndef VL53L1_TUNINGPARM_PRIVATE_PAGE_BASE_ADDRESS
 #define VL53L1_TUNINGPARM_PRIVATE_PAGE_BASE_ADDRESS 0xC000
+#endif
 
+#ifndef VL53L1_OFFSET_CAL_MIN_MM1_EFFECTIVE_SPADS
 #define VL53L1_OFFSET_CAL_MIN_MM1_EFFECTIVE_SPADS  0x0500
 /*!< Lower Limit for the  MM1 effective SPAD count during offset
      calibration Format 8.8 0x0500 -> 5.0 effective SPADs */
+#endif
 
+#ifndef VL53L1_GAIN_FACTOR__STANDARD_DEFAULT
 #define VL53L1_GAIN_FACTOR__STANDARD_DEFAULT       0x0800
 /*!<  Default standard ranging gain correction factor
       1.11 format. 1.0 = 0x0800, 0.980 = 0x07D7 */
+#endif
+#ifndef VL53L1_GAIN_FACTOR__HISTOGRAM_DEFAULT
 #define VL53L1_GAIN_FACTOR__HISTOGRAM_DEFAULT      0x0800
 /*!<  Default histogram ranging gain correction factor
      1.11 format. 1.0 = 0x0800, 0.975 = 0x07CC */
+#endif
 
 
+#ifndef VL53L1_OFFSET_CAL_MIN_EFFECTIVE_SPADS
 #define VL53L1_OFFSET_CAL_MIN_EFFECTIVE_SPADS  0x0500
 /*!< Lower Limit for the  MM1 effective SPAD count during offset
      calibration Format 8.8 0x0500 -> 5.0 effective SPADs */
+#endif
 
+#ifndef VL53L1_OFFSET_CAL_MAX_PRE_PEAK_RATE_MCPS
 #define VL53L1_OFFSET_CAL_MAX_PRE_PEAK_RATE_MCPS   0x1900
 /*!< Max Limit for the pre range preak rate during offset
      calibration Format 9.7 0x1900 -> 50.0 Mcps.
      If larger then in pile up */
+#endif
 
+#ifndef VL53L1_OFFSET_CAL_MAX_SIGMA_MM
 #define VL53L1_OFFSET_CAL_MAX_SIGMA_MM             0x0040
 /*!< Max sigma estimate limit during offset calibration
      Check applies to pre-range, mm1 and mm2 ranges
      Format 14.2 0x0040 -> 16.0mm. */
+#endif
 
+#ifndef VL53L1_ZONE_CAL_MAX_PRE_PEAK_RATE_MCPS
 #define VL53L1_ZONE_CAL_MAX_PRE_PEAK_RATE_MCPS     0x1900
 /*!< Max Peak Rate Limit for the during zone calibration
      Format 9.7 0x1900 -> 50.0 Mcps.
      If larger then in pile up */
+#endif
 
+#ifndef VL53L1_ZONE_CAL_MAX_SIGMA_MM
 #define VL53L1_ZONE_CAL_MAX_SIGMA_MM               0x0040
 /*!< Max sigma estimate limit during zone calibration
      Format 14.2 0x0040 -> 16.0mm. */
+#endif
 
 
+#ifndef VL53L1_XTALK_EXTRACT_MAX_SIGMA_MM
 #define VL53L1_XTALK_EXTRACT_MAX_SIGMA_MM          0x008C
 /*!< Max Sigma value allowed for a successful xtalk extraction
      Format 14.2 0x008C -> 35.0 mm.*/
+#endif
 
 #ifndef VL53L1_MAX_USER_ZONES
   #define VL53L1_MAX_USER_ZONES                5
@@ -98,14 +144,19 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   FW stream divide - value of 254 */
 #endif
 
+#ifndef VL53L1_MAX_RANGE_RESULTS
 #define VL53L1_MAX_RANGE_RESULTS              4
+#endif
+#ifndef VL53L1_BUFFER_SIZE
 #define VL53L1_BUFFER_SIZE              5
-
 /*!< Sets the maximum number of targets distances the histogram
    post processing can generate */
+#endif
 
+#ifndef VL53L1_MAX_STRING_LENGTH
 #define VL53L1_MAX_STRING_LENGTH 512
 /*!< Sets the maximum string length */
+#endif
 
 #endif  /* _VL53L1_PLATFORM_USER_CONFIG_H_ */
 

--- a/src/vl53l1_platform_user_config.h
+++ b/src/vl53l1_platform_user_config.h
@@ -34,17 +34,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * The default configuration values may be customized without modifying the library code by either:
  *
  * - Predefining the macro using a preprocessor option.
- *   Using Arduino IDE this can be achieved with help of the
- *   [`platform.local.txt`](https://arduino.github.io/arduino-cli/0.20/platform-specification/#platformlocaltxt)
- *   configuration file.
- *   For example to change the value of `VL53L1_MAX_RANGE_RESULTS` to `1` add this line to
- *   `platform.local.txt`:
- *   ```
- *   compiler.cpp.extra_flags=-DVL53L1_MAX_RANGE_RESULTS=1
- *   ```
+ *   - Using Arduino IDE this can be achieved with help of the
+ *     [`platform.local.txt`](https://arduino.github.io/arduino-cli/0.20/platform-specification/#platformlocaltxt)
+ *     configuration file.
+ *     For example to change the value of `VL53L1_MAX_RANGE_RESULTS` to `1` add this line to
+ *     `platform.local.txt`:
+ *
+ *         compiler.cpp.extra_flags=-DVL53L1_MAX_RANGE_RESULTS=1
+ *
  * - Providing alternative macro definitions within a file named `platform_config_custom.h` which
  *   must be locatable by the preprocessor.
- *   For this to work the compiler must support C++17 or newer.
+ *   For this to work the compiler must support conditional inclusion (`__has_include`) which is
+ *   part of C++17 or newer.
  */
 
 

--- a/src/vl53l1_platform_user_config.h
+++ b/src/vl53l1_platform_user_config.h
@@ -52,99 +52,99 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _VL53L1_PLATFORM_USER_CONFIG_H_
 
 #if __cplusplus >= 201703L /* for C++17 or newer */
-#if __has_include("platform_config_custom.h")
-  #include "platform_config_custom.h"
-#endif
+  #if __has_include("platform_config_custom.h")
+    #include "platform_config_custom.h"
+  #endif
 #endif /* end C++17 block */
 
 #ifndef VL53L1_BYTES_PER_WORD
-#define    VL53L1_BYTES_PER_WORD              2
+  #define    VL53L1_BYTES_PER_WORD              2
 #endif
 #ifndef VL53L1_BYTES_PER_DWORD
-#define    VL53L1_BYTES_PER_DWORD             4
+  #define    VL53L1_BYTES_PER_DWORD             4
 #endif
 
 /* Define polling delays */
 #ifndef VL53L1_BOOT_COMPLETION_POLLING_TIMEOUT_MS
-#define VL53L1_BOOT_COMPLETION_POLLING_TIMEOUT_MS     500
+  #define VL53L1_BOOT_COMPLETION_POLLING_TIMEOUT_MS     500
 #endif
 #ifndef VL53L1_RANGE_COMPLETION_POLLING_TIMEOUT_MS
-#define VL53L1_RANGE_COMPLETION_POLLING_TIMEOUT_MS   2000
+  #define VL53L1_RANGE_COMPLETION_POLLING_TIMEOUT_MS   2000
 #endif
 #ifndef VL53L1_TEST_COMPLETION_POLLING_TIMEOUT_MS
-#define VL53L1_TEST_COMPLETION_POLLING_TIMEOUT_MS   10000
+  #define VL53L1_TEST_COMPLETION_POLLING_TIMEOUT_MS   10000
 #endif
 
 #ifndef VL53L1_POLLING_DELAY_MS
-#define VL53L1_POLLING_DELAY_MS                         1
+  #define VL53L1_POLLING_DELAY_MS                         1
 #endif
 
 /* Define LLD TuningParms Page Base Address
  * - Part of Patch_AddedTuningParms_11761
  */
 #ifndef VL53L1_TUNINGPARM_PUBLIC_PAGE_BASE_ADDRESS
-#define VL53L1_TUNINGPARM_PUBLIC_PAGE_BASE_ADDRESS  0x8000
+  #define VL53L1_TUNINGPARM_PUBLIC_PAGE_BASE_ADDRESS  0x8000
 #endif
 #ifndef VL53L1_TUNINGPARM_PRIVATE_PAGE_BASE_ADDRESS
-#define VL53L1_TUNINGPARM_PRIVATE_PAGE_BASE_ADDRESS 0xC000
+  #define VL53L1_TUNINGPARM_PRIVATE_PAGE_BASE_ADDRESS 0xC000
 #endif
 
 #ifndef VL53L1_OFFSET_CAL_MIN_MM1_EFFECTIVE_SPADS
-#define VL53L1_OFFSET_CAL_MIN_MM1_EFFECTIVE_SPADS  0x0500
-/*!< Lower Limit for the  MM1 effective SPAD count during offset
-     calibration Format 8.8 0x0500 -> 5.0 effective SPADs */
+  #define VL53L1_OFFSET_CAL_MIN_MM1_EFFECTIVE_SPADS  0x0500
+  /*!< Lower Limit for the  MM1 effective SPAD count during offset
+  calibration Format 8.8 0x0500 -> 5.0 effective SPADs */
 #endif
 
 #ifndef VL53L1_GAIN_FACTOR__STANDARD_DEFAULT
-#define VL53L1_GAIN_FACTOR__STANDARD_DEFAULT       0x0800
-/*!<  Default standard ranging gain correction factor
-      1.11 format. 1.0 = 0x0800, 0.980 = 0x07D7 */
+  #define VL53L1_GAIN_FACTOR__STANDARD_DEFAULT       0x0800
+  /*!<  Default standard ranging gain correction factor
+  1.11 format. 1.0 = 0x0800, 0.980 = 0x07D7 */
 #endif
 #ifndef VL53L1_GAIN_FACTOR__HISTOGRAM_DEFAULT
-#define VL53L1_GAIN_FACTOR__HISTOGRAM_DEFAULT      0x0800
-/*!<  Default histogram ranging gain correction factor
-     1.11 format. 1.0 = 0x0800, 0.975 = 0x07CC */
+  #define VL53L1_GAIN_FACTOR__HISTOGRAM_DEFAULT      0x0800
+  /*!<  Default histogram ranging gain correction factor
+  1.11 format. 1.0 = 0x0800, 0.975 = 0x07CC */
 #endif
 
 
 #ifndef VL53L1_OFFSET_CAL_MIN_EFFECTIVE_SPADS
-#define VL53L1_OFFSET_CAL_MIN_EFFECTIVE_SPADS  0x0500
-/*!< Lower Limit for the  MM1 effective SPAD count during offset
-     calibration Format 8.8 0x0500 -> 5.0 effective SPADs */
+  #define VL53L1_OFFSET_CAL_MIN_EFFECTIVE_SPADS  0x0500
+  /*!< Lower Limit for the  MM1 effective SPAD count during offset
+  calibration Format 8.8 0x0500 -> 5.0 effective SPADs */
 #endif
 
 #ifndef VL53L1_OFFSET_CAL_MAX_PRE_PEAK_RATE_MCPS
-#define VL53L1_OFFSET_CAL_MAX_PRE_PEAK_RATE_MCPS   0x1900
-/*!< Max Limit for the pre range preak rate during offset
-     calibration Format 9.7 0x1900 -> 50.0 Mcps.
-     If larger then in pile up */
+  #define VL53L1_OFFSET_CAL_MAX_PRE_PEAK_RATE_MCPS   0x1900
+  /*!< Max Limit for the pre range preak rate during offset
+  calibration Format 9.7 0x1900 -> 50.0 Mcps.
+  If larger then in pile up */
 #endif
 
 #ifndef VL53L1_OFFSET_CAL_MAX_SIGMA_MM
-#define VL53L1_OFFSET_CAL_MAX_SIGMA_MM             0x0040
-/*!< Max sigma estimate limit during offset calibration
-     Check applies to pre-range, mm1 and mm2 ranges
-     Format 14.2 0x0040 -> 16.0mm. */
+  #define VL53L1_OFFSET_CAL_MAX_SIGMA_MM             0x0040
+  /*!< Max sigma estimate limit during offset calibration
+  Check applies to pre-range, mm1 and mm2 ranges
+  Format 14.2 0x0040 -> 16.0mm. */
 #endif
 
 #ifndef VL53L1_ZONE_CAL_MAX_PRE_PEAK_RATE_MCPS
-#define VL53L1_ZONE_CAL_MAX_PRE_PEAK_RATE_MCPS     0x1900
-/*!< Max Peak Rate Limit for the during zone calibration
-     Format 9.7 0x1900 -> 50.0 Mcps.
-     If larger then in pile up */
+  #define VL53L1_ZONE_CAL_MAX_PRE_PEAK_RATE_MCPS     0x1900
+  /*!< Max Peak Rate Limit for the during zone calibration
+  Format 9.7 0x1900 -> 50.0 Mcps.
+  If larger then in pile up */
 #endif
 
 #ifndef VL53L1_ZONE_CAL_MAX_SIGMA_MM
-#define VL53L1_ZONE_CAL_MAX_SIGMA_MM               0x0040
-/*!< Max sigma estimate limit during zone calibration
-     Format 14.2 0x0040 -> 16.0mm. */
+  #define VL53L1_ZONE_CAL_MAX_SIGMA_MM               0x0040
+  /*!< Max sigma estimate limit during zone calibration
+  Format 14.2 0x0040 -> 16.0mm. */
 #endif
 
 
 #ifndef VL53L1_XTALK_EXTRACT_MAX_SIGMA_MM
-#define VL53L1_XTALK_EXTRACT_MAX_SIGMA_MM          0x008C
-/*!< Max Sigma value allowed for a successful xtalk extraction
-     Format 14.2 0x008C -> 35.0 mm.*/
+  #define VL53L1_XTALK_EXTRACT_MAX_SIGMA_MM          0x008C
+  /*!< Max Sigma value allowed for a successful xtalk extraction
+  Format 14.2 0x008C -> 35.0 mm.*/
 #endif
 
 #ifndef VL53L1_MAX_USER_ZONES
@@ -154,17 +154,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #ifndef VL53L1_MAX_RANGE_RESULTS
-#define VL53L1_MAX_RANGE_RESULTS              4
+  #define VL53L1_MAX_RANGE_RESULTS              4
 #endif
 #ifndef VL53L1_BUFFER_SIZE
-#define VL53L1_BUFFER_SIZE              5
-/*!< Sets the maximum number of targets distances the histogram
-   post processing can generate */
+  #define VL53L1_BUFFER_SIZE              5
+  /*!< Sets the maximum number of targets distances the histogram
+  post processing can generate */
 #endif
 
 #ifndef VL53L1_MAX_STRING_LENGTH
-#define VL53L1_MAX_STRING_LENGTH 512
-/*!< Sets the maximum string length */
+  #define VL53L1_MAX_STRING_LENGTH 512
+  /*!< Sets the maximum string length */
 #endif
 
 #endif  /* _VL53L1_PLATFORM_USER_CONFIG_H_ */

--- a/src/vl53l1_platform_user_config.h
+++ b/src/vl53l1_platform_user_config.h
@@ -51,11 +51,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _VL53L1_PLATFORM_USER_CONFIG_H_
 #define _VL53L1_PLATFORM_USER_CONFIG_H_
 
-#if __cplusplus >= 201703L /* for C++17 or newer */
+#if defined(__has_include)
   #if __has_include("platform_config_custom.h")
     #include "platform_config_custom.h"
   #endif
-#endif /* end C++17 block */
+#endif /* __has_include */
 
 #ifndef VL53L1_BYTES_PER_WORD
   #define    VL53L1_BYTES_PER_WORD              2

--- a/src/vl53l1_platform_user_config.h
+++ b/src/vl53l1_platform_user_config.h
@@ -42,11 +42,20 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *   ```
  *   compiler.cpp.extra_flags=-DVL53L1_MAX_RANGE_RESULTS=1
  *   ```
+ * - Providing alternative macro definitions within a file named `platform_config_custom.h` which
+ *   must be locatable by the preprocessor.
+ *   For this to work the compiler must support C++17 or newer.
  */
 
 
 #ifndef _VL53L1_PLATFORM_USER_CONFIG_H_
 #define _VL53L1_PLATFORM_USER_CONFIG_H_
+
+#if __cplusplus >= 201703L /* for C++17 or newer */
+#if __has_include("platform_config_custom.h")
+  #include "platform_config_custom.h"
+#endif
+#endif /* end C++17 block */
 
 #ifndef VL53L1_BYTES_PER_WORD
 #define    VL53L1_BYTES_PER_WORD              2


### PR DESCRIPTION
The user manual (UM2133) suggests that this macro can be configured:
 
> VL53L1_MAX_RANGE_RESULTS [...] **by default**, is equal to four.

(from Rev 6 page 10, highlighting by me)

The value can be passed to the preprocessor as predefined macro.

Using Arduino IDE this can be achieved with help of the [`platform.local.txt`](https://arduino.github.io/arduino-cli/0.20/platform-specification/#platformlocaltxt) configuration file. For example to change the value to `1` add this line to `platform.local.txt`:

    compiler.cpp.extra_flags=-DVL53L1_MAX_RANGE_RESULTS=1

This change applies the same mechanism as already exists for `VL53L1_MAX_USER_ZONES` [some lines further up](https://github.com/dhebbeker/VL53L1/blob/902e9f8788c9d632a1d256e754461434f759c615/src/vl53l1_platform_user_config.h#L95).